### PR TITLE
GREEN-1135: Passing field_name as None did not work in Python2.7

### DIFF
--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -715,7 +715,9 @@ class Instance:
 
 		This is an alternative to :meth:`set_number`, :meth:`set_string` and :meth:`set_boolean`
 		"""
-		if isinstance(value, Number):
+		if field_name is None:
+			raise AttributeError("field_name cannot be None")
+		elif isinstance(value, Number):
 			self.set_number(field_name, value)
 		elif isinstance(value, str):
 			self.set_string(field_name, value)
@@ -731,7 +733,9 @@ class Instance:
 		:param number value: A numeric value or ``None`` to unset an optional member
 		"""
 
-		if value is None:
+		if field_name is None:
+			raise AttributeError("field_name cannot be None")
+		elif value is None:
 			self.clear_member(field_name)
 		else:
 			try:
@@ -755,7 +759,9 @@ class Instance:
 		:param number value: ``True`` or ``False``, or ``None`` to unset an optional member
 		"""
 
-		if value is None:
+		if field_name is None:
+			raise AttributeError("field_name cannot be None")
+		elif value is None:
 			self.clear_member(field_name)
 		else:
 			try:
@@ -779,7 +785,9 @@ class Instance:
 		:param str value: The string value or ``None`` to unset an optional member
 		"""
 
-		if value is None:
+		if field_name is None:
+			raise AttributeError("field_name cannot be None")
+		elif value is None:
 			self.clear_member(field_name)
 		else:
 			try:

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -505,8 +505,7 @@ class TestDataAccess:
       test_output.instance.set_boolean(None, True)
     with pytest.raises(AttributeError) as excinfo:
       test_output.instance.set_number(None, 42)
-    # For set_string, TypeError is raised in this situation
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(AttributeError) as excinfo:
       test_output.instance.set_string(None, "Hello")
 
     # Try to set a number with a string


### PR DESCRIPTION
In Python3, passing field_name as NULL resulted in an exception being raised.
In Python2.7 this exception was not raised and the field_name argument was
interpreted as NULL in the binding.
This has been resolved and made consistent between the 2 python verisons.