### PR TITLE
CON-138: Allow getting complex members with __getitem__

### DIFF
--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -86,6 +86,13 @@ def _check_retcode(retcode):
 		else:
 			raise Error("DDS Exception: " + _get_last_dds_error_message())
 
+# Definition of this class must match the RTI_Connecot_AnyValueKind enum in ddsConnector.ifc
+class _AnyValueKind:
+	connector_none = 0
+	connector_number = 1
+	connector_boolean = 2
+	connector_string = 3
+
 class _ConnectorBinding:
 	def __init__(self):
 		(bits, linkage) = platform.architecture()
@@ -464,12 +471,16 @@ class SampleIterator:
 		if retcode == _ReturnCode.no_data:
 			return None
 
-		if selection.value == 1:
+		if selection.value == _AnyValueKind.connector_number:
 			return number_value.value
-		elif selection.value == 2:
+		elif selection.value == _AnyValueKind.connector_boolean:
 			return bool_value.value
-		elif selection.value == 3:
-			return _move_native_string(string_value)
+		elif selection.value == _AnyValueKind.connector_string:
+			python_string = _move_native_string(string_value)
+			try:
+				return json.loads(python_string)
+			except ValueError as e:
+				return python_string
 		else:
 			# This shouldn't happen
 			raise Error("Unexpected connector_binding.getAnyValueFromSamples result")

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -525,3 +525,39 @@ class TestDataAccess:
       test_output.instance.set_string("NonExistent", 1)
     with pytest.raises(rti.Error) as excinfo:
       test_output.instance.set_boolean("NonExistent", 1)
+
+  def test_get_complex_with_getitem(self, populated_input):
+    sample = populated_input[0]
+
+    point = sample["my_point"]
+    # Structs converted to dict
+    assert isinstance(point, dict)
+    assert point['x'] == 3
+    assert point['y'] == 4
+
+    point_sequence = sample["my_point_sequence"]
+    # Sequences converted to list
+    assert isinstance(point_sequence, list)
+    assert point_sequence[0] == {'x': 10, 'y': 20}
+    assert point_sequence[1] == {'x': 11, 'y': 21}
+
+    point_array = sample["my_point_array"]
+    # Arrays converted to list
+    assert isinstance(point_array, list)
+    assert point_array[0] == {'x': 0, 'y': 0}
+    assert point_array[4] == {'x': 5, 'y': 15}
+
+    point_alias = sample["my_point_alias"]
+    # Alias should be resolved (so in this case become a struct -> dict)
+    assert isinstance(point_alias, dict)
+    assert point_alias['x'] == 30
+    assert point_alias['y'] == 40
+
+    optional_point = sample["my_optional_point"]
+    # Unset optional should return None
+    assert optional_point is None
+
+    union = sample["my_union"]
+    # If no trailing '#' is supplied should obtain the union as a struct -> dict
+    assert isinstance(union, dict)
+    assert union == {'my_int_sequence': [10, 20, 30]}


### PR DESCRIPTION
- Duplicated the AnyValueKind enum in connector so that we can use those values
  instead of the integers directly
- When a string is returned by getAny, check if it can be loaded as JSON.
  If it can do this (returning either dict or list depending on TCKind).
  If not, return the string as before.
- Unit tests to verify new functionality