### PR TITLE
CON-139: Support write options as kwargs; expand support for SampleInfo

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -198,6 +198,10 @@ with numeric fields, returning the number as a string. For example:
     to ``get_dictionary`` or ``set_dictionary`` when the intention is to access
     most of the fields of the sample (see previous section).
 
+.. note::
+    If a field ``my_string``, defined as a string in the configuration file contains
+    a value that can be interpreted as a number, ``sample["my_string"]`` returns
+    a number, not a string.
 
 Accessing structs
 ^^^^^^^^^^^^^^^^^

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -111,7 +111,7 @@ You can access a field of the sample meta-data, the *SampleInfo*, as follows:
 .. testcode::
 
    for sample in input.data_iterator:
-      valid = sample.info["valid_data"]
+      source_timestamp = sample.info["source_timestamp"]
 
 
 See :meth:`SampleIterator.info` for the list of meta-data fields available

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -72,6 +72,13 @@ data sample::
 
     output.wait()
 
+The write method can receive several options. For example, to
+write with a specific timestamp:
+
+.. testcode::
+
+  output.write(source_timestamp=100000)
+
 Class reference: Output, Instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -278,10 +278,17 @@ class _ConnectorBinding:
 		elif selection.value == _AnyValueKind.connector_boolean:
 			return bool_value.value
 		elif selection.value == _AnyValueKind.connector_string:
+			# A string can represent three different things:
+			#  - An actual string value (handled in the except clause)
+			#  - A json string; we parse it and convert it to a dictionary
+			#  - An integer (larger than what number_value can represent precisely)
+			#    the same json parser returns the integer
 			python_string = _move_native_string(string_value)
 			try:
 				return json.loads(python_string)
 			except ValueError as e:
+				# This is the best way we have to detect that this is not a json
+				# string or an integer
 				return python_string
 		else:
 			# This shouldn't happen

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -93,3 +93,24 @@ def rtiOutputFixture(rtiConnectorFixture):
   """
 
   return rtiConnectorFixture.getOutput("MyPublisher::MySquareWriter")
+
+@pytest.fixture
+def one_use_connector(request):
+    """Creates a Connector only for one test. Use this when
+       the test can't reuse a previously created connector"""
+
+    xml_path = os.path.join(
+      os.path.dirname(os.path.realpath(__file__)),
+      "../xml/TestConnector.xml")
+
+    participant_profile="MyParticipantLibrary::Zero"
+    with rti.open_connector(participant_profile, xml_path) as rti_connector:
+      yield rti_connector
+
+@pytest.fixture
+def one_use_output(one_use_connector):
+  return one_use_connector.get_output("MyPublisher::MySquareWriter")
+
+@pytest.fixture
+def one_use_input(one_use_connector):
+  return one_use_connector.get_input("MySubscriber::MySquareReader")  

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -627,7 +627,3 @@ class TestDataAccess:
     assert isinstance(point_array_str, str)
     assert isinstance(json.loads(point_array_str), list)
 
-  def test_get_any_from_info(self, populated_input):
-    assert populated_input[0].info['valid_data'] == True
-    assert populated_input[0].info['source_timestamp'] > 0
-    assert populated_input[0].info['reception_timestamp'] > 0

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -9,6 +9,7 @@
 import pytest,time,sys,os,ctypes,json
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../")
 import rticonnextdds_connector as rti
+from test_utils import *
 
 
 class TestDataAccess:
@@ -67,24 +68,6 @@ class TestDataAccess:
   def test_input(self, test_connector):
     return test_connector.get_input("TestSubscriber::TestReader2")
 
-  def wait_for_data(self, input, count = 1, do_take = True):
-    """Waits until input has count samples"""
-
-    for i in range(1, 5):
-      input.read()
-      if input.sample_count == count:
-        break
-      input.wait(1000)
-
-    assert input.sample_count == count
-    if do_take:
-      input.take()
-
-  def send_data(self, output, input):
-    output.write()
-    self.wait_for_data(input)
-    return input[0]
-
   @pytest.fixture(scope="class")
   def populated_input(self, test_connector, test_dictionary):
     """Writes a default sample and receives it at the input.
@@ -96,7 +79,7 @@ class TestDataAccess:
     output.write()
 
     test_input = test_connector.get_input("TestSubscriber::TestReader")
-    self.wait_for_data(input = test_input, count = 1, do_take = True)
+    wait_for_data(input = test_input, count = 1, do_take = True)
 
     assert test_input.sample_count == 1
     assert test_input[0].valid_data
@@ -125,8 +108,15 @@ class TestDataAccess:
   def test_set_boolean_as_number(self, test_output, test_input):
     test_output.instance.set_number("my_optional_bool", 1)
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
     assert test_input[0]["my_optional_bool"] == True
+
+  def test_numeric_string(self, test_output, test_input):
+    test_output.instance["my_string"] = "1234"
+    sample = send_data(test_output, test_input)
+    # A side effect of CON-139: __getitem__ automatically parses strings and
+    # returns them as numbers if they represent a number
+    assert sample["my_string"] == 1234
 
   def test_get_enum(self, populated_input):
     sample = populated_input[0]
@@ -155,7 +145,7 @@ class TestDataAccess:
     test_output.instance["my_int_sequence[1]"] = 2
     test_output.instance["my_point_array[4].x"] = 5
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
 
     sample = test_input[0]
     assert sample["my_point_sequence[0].y"] == 20
@@ -208,13 +198,13 @@ class TestDataAccess:
   def test_change_union_member(self, test_output, test_input):
     test_output.instance.set_number("my_union.my_int_sequence[1]", 3)
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
     sample = test_input[0]
     assert sample.get_string("my_union#") == "my_int_sequence"
 
     test_output.instance.set_number("my_union.my_long", 3)
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
 
     sample = test_input[0]
     assert sample.get_string("my_union#") == "my_long"
@@ -224,7 +214,7 @@ class TestDataAccess:
     test_output.instance.set_number("my_optional_point.x", 101)
     test_output.instance["my_point_alias.x"] = 202
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
 
     sample = test_input[0]
     assert sample.get_number("my_optional_point.x") == 101
@@ -243,7 +233,7 @@ class TestDataAccess:
 
   def test_unset_optional_boolean(self, test_output, test_input):
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
     assert test_input[0].get_boolean("my_optional_bool") is None
 
   def test_unset_complex_optional(self, populated_input):
@@ -263,7 +253,7 @@ class TestDataAccess:
     test_output.instance.set_number("my_optional_long", 33)
     test_output.instance.set_number("my_optional_long", None)
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
     assert test_input[0].get_number("my_optional_long") is None
     assert not "my_optional_long" in test_input[0].get_dictionary()
 
@@ -271,7 +261,7 @@ class TestDataAccess:
     test_output.instance.set_boolean("my_optional_bool", True)
     test_output.instance.set_boolean("my_optional_bool", None)
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
     sample = test_input[0]
     assert sample.get_boolean("my_optional_bool") is None
     assert sample["my_optional_bool"] is None
@@ -283,7 +273,7 @@ class TestDataAccess:
     test_output.instance.clear_member("my_optional_point")
     test_output.instance.clear_member("my_point_alias")
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
     assert test_input[0].get_number("my_optional_point.x") is None
     assert test_input[0].get_number("my_point_alias.x") is None
     assert test_input[0]["my_optional_point.x"] is None
@@ -292,7 +282,7 @@ class TestDataAccess:
     test_output.instance.set_number("my_point.x", 44)
     test_output.instance.clear_member("my_point")
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
     assert test_input[0].get_number("my_point.x") == 0
 
   def test_clear_sequence(self, test_output, test_input):
@@ -301,7 +291,7 @@ class TestDataAccess:
     test_output.instance.clear_member("my_union.my_int_sequence")
     test_output.write()
 
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
     assert test_input[0].get_number("my_union.my_int_sequence#") == 0
     assert test_input[0].get_number("my_point.x") == 3
 
@@ -327,7 +317,7 @@ class TestDataAccess:
       'my_enum': None,
     })
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
 
     sample = test_input[0]
     assert sample.get_number("my_optional_point.x") is None
@@ -344,7 +334,7 @@ class TestDataAccess:
     assert sample.get_number("my_enum") == 2
     assert sample.get_number("my_double") == test_dictionary['my_double']
     dictionary = sample.get_dictionary()
-    print(dictionary)
+
     assert not "my_optional_bool" in dictionary
     assert not "my_optional_long" in dictionary
     assert not "my_point_alias" in dictionary
@@ -359,14 +349,14 @@ class TestDataAccess:
     test_output.instance.set_number("my_union.my_int_sequence[2]", 10)
     test_output.instance.set_number("my_point.x", 3)
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
 
     assert test_input[0].get_number("my_point.x") == 3
     assert test_input[0].get_number("my_union.my_int_sequence#") == 3
 
     test_output.instance.set_dictionary({'my_int_sequence':[]})
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
 
     sample = test_input[0]
     assert sample.get_number("my_int_sequence#") == 0
@@ -437,7 +427,7 @@ class TestDataAccess:
       "my_point_sequence":[{"y":2}],
       "my_point_array":[{"x":100}, {"y":200}]})
     test_output.write()
-    self.wait_for_data(test_input)
+    wait_for_data(test_input)
 
     sample = test_input[0]
     assert sample["my_int_sequence#"] == 1 # Length reduced
@@ -462,7 +452,7 @@ class TestDataAccess:
       output.instance.set_number("my_int64", -number)
 
     output.instance.set_dictionary({"my_uint64": number, "my_int64":-number})
-    sample = self.send_data(output, input)
+    sample = send_data(output, input)
     dictionary = sample.get_dictionary()
     assert dictionary["my_uint64"] == number
     assert dictionary["my_int64"] == -number
@@ -478,7 +468,7 @@ class TestDataAccess:
     # largest integer allowed in set_number
     test_output.instance.set_number("my_uint64", max_int_set)
     test_output.instance.set_number("my_int64", -max_int_set)
-    sample = self.send_data(test_output, test_input)
+    sample = send_data(test_output, test_input)
     assert sample.get_number("my_uint64") == max_int_set
     assert sample.get_number("my_int64") == -max_int_set
 
@@ -486,7 +476,7 @@ class TestDataAccess:
     # __setitem__ will also use
     test_output.instance["my_uint64"] = max_int_get
     test_output.instance.set_dictionary({"my_int64":-max_int_get})
-    sample = self.send_data(test_output, test_input)
+    sample = send_data(test_output, test_input)
     assert sample.get_number("my_uint64") == max_int_get
     assert sample.get_number("my_int64") == -max_int_get
 
@@ -639,3 +629,5 @@ class TestDataAccess:
 
   def test_get_any_from_info(self, populated_input):
     assert populated_input[0].info['valid_data'] == True
+    assert populated_input[0].info['source_timestamp'] > 0
+    assert populated_input[0].info['reception_timestamp'] > 0

--- a/test/python/test_rticonnextdds_metadata.py
+++ b/test/python/test_rticonnextdds_metadata.py
@@ -1,0 +1,60 @@
+###############################################################################
+# (c) 2005-2015 Copyright, Real-Time Innovations.  All rights reserved.       #
+# No duplications, whole or partial, manual or electronic, may be made        #
+# without express written permission.  Any such copies, or revisions thereof, #
+# must display this notice unaltered.                                         #
+# This code contains trade secrets of Real-Time Innovations, Inc.             #
+###############################################################################
+
+import pytest,time,sys,os,ctypes
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../")
+import rticonnextdds_connector as rti
+from test_utils import *
+
+
+class TestMetadata:
+  """
+  This class tests write with options and sample info
+  """
+
+  def test_bad_info_field(self, one_use_output, one_use_input):
+    sample = send_data(one_use_output, one_use_input)
+    with pytest.raises(rti.Error, match=r".*Unknown.*nonexistent.*") as excinfo:
+      sample.info["nonexistent"]
+
+  def test_timestamp(self, one_use_output, one_use_input):
+    sample = send_data(one_use_output, one_use_input, source_timestamp=2)
+    assert sample.info["source_timestamp"] == 2
+    assert sample.info["reception_timestamp"] != 2 and sample.info["reception_timestamp"] > 0
+
+  def test_large_timestamp(self, one_use_output, one_use_input):
+    n = 9007199254740999 # Loses precission as a double
+    sample = send_data(one_use_output, one_use_input, source_timestamp=n)
+    assert sample.info["source_timestamp"] == n
+
+    n = 2147483647999999999 # DDS_TIME_MAX (0x7fffffff seconds + 999999999 ns)
+    sample = send_data(one_use_output, one_use_input, source_timestamp=n)
+    assert sample.info["source_timestamp"] == n
+
+    n = n + 1
+    with pytest.raises(rti.Error, match=r".*timestamp is larger than DDS_TIME_MAX.*") as excinfo:
+      send_data(one_use_output, one_use_input, source_timestamp=n)
+
+  def test_sample_identity(self, one_use_output, one_use_input):
+    sample_id = {
+      "writer_guid": [10,30,1,66,0,0,29,180,0,0,0,1,128,0,0,3],
+      "sequence_number": 10
+    }
+    related_sample_id = {
+      "writer_guid": [11,30,1,66,0,0,29,180,0,0,0,1,128,0,0,34],
+      "sequence_number": 2**63-1 # LLONG_MAX
+    }
+
+    sample = send_data(
+      one_use_output,
+      one_use_input,
+      identity=sample_id,
+      related_sample_identity=related_sample_id)
+
+    assert sample.info["sample_identity"] == sample_id
+    assert sample.info["related_sample_identity"] == related_sample_id

--- a/test/python/test_rticonnextdds_metadata.py
+++ b/test/python/test_rticonnextdds_metadata.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# (c) 2005-2015 Copyright, Real-Time Innovations.  All rights reserved.       #
+# (c) 2019 Copyright, Real-Time Innovations.  All rights reserved.            #
 # No duplications, whole or partial, manual or electronic, may be made        #
 # without express written permission.  Any such copies, or revisions thereof, #
 # must display this notice unaltered.                                         #
@@ -24,8 +24,9 @@ class TestMetadata:
 
   def test_timestamp(self, one_use_output, one_use_input):
     sample = send_data(one_use_output, one_use_input, source_timestamp=2)
+    assert sample.info["valid_data"] == True
     assert sample.info["source_timestamp"] == 2
-    assert sample.info["reception_timestamp"] != 2 and sample.info["reception_timestamp"] > 0
+    assert sample.info["reception_timestamp"] > 2
 
   def test_large_timestamp(self, one_use_output, one_use_input):
     n = 9007199254740999 # Loses precission as a double

--- a/test/python/test_rticonnextdds_metadata.py
+++ b/test/python/test_rticonnextdds_metadata.py
@@ -66,6 +66,11 @@ class TestMetadata:
     assert sample.info["sample_identity"] == expected_id
 
   def test_bad_guid(self, one_use_output):
+
+    not_an_array = {"writer_guid": 3, "sequence_number": 10}
+    with pytest.raises(rti.Error, match=r".*error parsing GUID.*") as excinfo:
+      one_use_output.write(identity=not_an_array)
+
     too_long = {"writer_guid": [1] * 17, "sequence_number": 10}
     with pytest.raises(rti.Error, match=r".*octet array exceeds maximum length of 16.*") as excinfo:
       one_use_output.write(identity=too_long)

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# (c) 2005-2015 Copyright, Real-Time Innovations.  All rights reserved.       #
+# (c) 2019 Copyright, Real-Time Innovations.  All rights reserved.            #
 # No duplications, whole or partial, manual or electronic, may be made        #
 # without express written permission.  Any such copies, or revisions thereof, #
 # must display this notice unaltered.                                         #

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -1,0 +1,34 @@
+###############################################################################
+# (c) 2005-2015 Copyright, Real-Time Innovations.  All rights reserved.       #
+# No duplications, whole or partial, manual or electronic, may be made        #
+# without express written permission.  Any such copies, or revisions thereof, #
+# must display this notice unaltered.                                         #
+# This code contains trade secrets of Real-Time Innovations, Inc.             #
+###############################################################################
+
+import sys, os, pytest, threading, time
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__))+ "/../../")
+import rticonnextdds_connector as rti
+
+
+def wait_for_data(input, count = 1, do_take = True):
+  """Waits until input has count samples"""
+
+  for i in range(1, 5):
+    input.read()
+    if input.sample_count == count:
+      break
+    input.wait(1000)
+
+  assert input.sample_count == count
+  if do_take:
+    input.take()
+
+def send_data(output, input, **kwargs):
+  """Writes one sample with optional arguments (kwargs) and returns the sample
+  received by the input"""
+
+  output.write(**kwargs)
+  wait_for_data(input)
+  return input[0]

--- a/test/xml/TestConnector.xml
+++ b/test/xml/TestConnector.xml
@@ -136,6 +136,7 @@ This code contains trade secrets of Real-Time Innovations, Inc.
         <domain name="MyDomain" domain_id="0">
             <register_type name="ShapeType" type_ref="ShapeType" />
             <topic name="Square" register_type_ref="ShapeType"/>
+            <topic name="Circle" register_type_ref="ShapeType"/>
         </domain>
         <domain name="DataAccessDomain" domain_id="0">
             <register_type name="MyType" type_ref="MyType" />
@@ -165,6 +166,18 @@ This code contains trade secrets of Real-Time Innovations, Inc.
             <subscriber name="TestSubscriber">
                 <data_reader name="TestReader" topic_ref="TestTopic" />
                 <data_reader name="TestReader2" topic_ref="TestTopic2" />
+            </subscriber>
+        </domain_participant>
+
+        <domain_participant name="TestRequestReply" domain_ref="MyDomainLibrary::MyDomain">
+            <publisher name="TestPublisher">
+                <data_writer name="RequestWriter" topic_ref="Square" />
+                <data_writer name="ReplyWriter" topic_ref="Circle" />
+            </publisher>
+
+            <subscriber name="TestSubscriber">
+                <data_reader name="RequestReader" topic_ref="Square" />
+                <data_reader name="ReplyReader" topic_ref="Circle" />
             </subscriber>
         </domain_participant>
     </domain_participant_library>


### PR DESCRIPTION
Also, add test_utils.py module, shared by data_access and the new metadata tester. Add new fixture one_use_input, one_use_output for tests that require a single-use Connector instance