### PR TITLE
CON-146: Test and document not autoenabling readers

### DIFF
--- a/docs/connector.rst
+++ b/docs/connector.rst
@@ -73,6 +73,16 @@ Once you have created a ``Connector`` instance, :meth:`Connector.get_output()`
 returns the :class:`Output` that allows writing data, and :meth:`Connector.get_input()`
 returns the :class:`Input` that allows reading data.
 
+.. note::
+
+  If the *domain_participant* you load contains both *data_writers* (Outputs) and
+  *data_readers* (Inputs) for the same topics, when you write data, the Inputs
+  will receive the data even before you call :meth:`Connector.get_input()`.
+  To avoid that, you can configure the *subscriber* that contains the
+  *data_reader* with ``<subscriber_qos>/<entity_factory>/<autoenable_created_entities>``
+  set to ``false``. In that case, the Inputs will only receive data after you
+  call :meth:`Connector.get_input()`.
+
 For more information see:
 
     * :ref:`Writing data (Output)`

--- a/docs/connector.rst
+++ b/docs/connector.rst
@@ -76,12 +76,13 @@ returns the :class:`Input` that allows reading data.
 .. note::
 
   If the *domain_participant* you load contains both *data_writers* (Outputs) and
-  *data_readers* (Inputs) for the same topics, when you write data, the Inputs
-  will receive the data even before you call :meth:`Connector.get_input()`.
-  To avoid that, you can configure the *subscriber* that contains the
-  *data_reader* with ``<subscriber_qos>/<entity_factory>/<autoenable_created_entities>``
-  set to ``false``. In that case, the Inputs will only receive data after you
-  call :meth:`Connector.get_input()`.
+  *data_readers* (Inputs) for the same topics and matching Qos, when you write
+  data, the Inputs will receive the data even before you call
+  :meth:`Connector.get_input()`. To avoid that, you can configure the
+  *subscriber* that contains the *data_reader* with
+  ``<subscriber_qos>/<entity_factory>/<autoenable_created_entities>`` set to
+  ``false``. In that case, the Inputs will only receive data after you call
+  :meth:`Connector.get_input()`.
 
 For more information see:
 

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -88,6 +88,11 @@ def _check_retcode(retcode):
 		else:
 			raise Error("DDS Exception: " + _get_last_dds_error_message())
 
+def _check_entity_creation(object, entity_name):
+	if object is None:
+		raise Error("Failed to create " + entity_name + ": "
+			+ _get_last_dds_error_message())
+
 # Definition of this class must match the RTI_Connecot_AnyValueKind enum in ddsConnector.ifc
 class _AnyValueKind:
 	connector_none = 0
@@ -640,8 +645,7 @@ class Input:
 		self.connector = connector
 		self.name = name
 		self.native = connector_binding.getReader(self.connector.native,tocstring(self.name))
-		if self.native is None:
-			raise ValueError("Invalid Subscription::DataReader name")
+		_check_entity_creation(self.native, "Input")
 		self.samples = Samples(self)
 		self.infos = Infos(self)
 
@@ -944,8 +948,7 @@ class Output:
 		self.connector = connector
 		self.name = name
 		self.native= connector_binding.getWriter(self.connector.native,tocstring(self.name))
-		if self.native ==None:
-			raise ValueError("Invalid Publication::DataWriter name")
+		_check_entity_creation(self.native, "Output")
 		self.instance = Instance(self)
 
 	def write(self, **kwargs):
@@ -1044,8 +1047,7 @@ class Connector:
 			tocstring(configName),
 			tocstring(url),
 			ctypes.byref(options))
-		if self.native is None:
-			raise ValueError("Invalid participant profile, xml path or xml profile")
+		_check_entity_creation(self.native, "Connector")
 
 	def close(self):
 		"""Frees all the resources created by this Connector instance"""

--- a/test/python/test_rticonnextdds_connector.py
+++ b/test/python/test_rticonnextdds_connector.py
@@ -24,7 +24,7 @@ class TestConnector:
     """
     participant_profile = "MyParticipantLibrary::Zero"
     invalid_xml_path = "invalid/path/to/xml"
-    with pytest.raises(ValueError):
+    with pytest.raises(rti.Error):
       connector = rti.Connector(participant_profile,invalid_xml_path)
 
   def test_invalid_participant_profile(self):
@@ -36,7 +36,7 @@ class TestConnector:
     invalid_participant_profile = "InvalidParticipantProfile"
     xml_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
       "../xml/TestConnector.xml")
-    with pytest.raises(ValueError):
+    with pytest.raises(rti.Error):
       connector = rti.Connector(invalid_participant_profile,xml_path)
 
   def test_ivalid_xml_profile(self):
@@ -48,7 +48,7 @@ class TestConnector:
     participant_profile = "MyParticipantLibrary::Zero"
     invalid_xml = os.path.join(os.path.dirname(os.path.realpath(__file__)),
       "../xml/InvalidXml.xml")
-    with pytest.raises(ValueError):
+    with pytest.raises(rti.Error):
       connector = rti.Connector(participant_profile,invalid_xml)
 
   def test_connector_creation(self,rtiConnectorFixture):

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -34,12 +34,8 @@ class TestDataAccess:
   def test_connector(self):
     """Creates the connector shared among all the tests in this class"""
 
-    xml_path = os.path.join(
-      os.path.dirname(os.path.realpath(__file__)),
-      "../xml/TestConnector.xml")
-
     participant_profile="MyParticipantLibrary::DataAccessTest"
-    with rti.open_connector(participant_profile, xml_path) as rti_connector:
+    with open_test_connector(participant_profile) as rti_connector:
       yield rti_connector
 
   @pytest.fixture(scope="class")

--- a/test/python/test_rticonnextdds_input.py
+++ b/test/python/test_rticonnextdds_input.py
@@ -9,6 +9,7 @@
 import pytest,sys,os,ctypes
 sys.path.append(os.path.dirname(os.path.realpath(__file__))+ "/../../")
 import rticonnextdds_connector as rti
+from test_utils import open_test_connector, wait_for_data
 
 class TestInput:
   """
@@ -33,7 +34,7 @@ class TestInput:
 
     """
     invalid_DR = "InvalidDR"
-    with pytest.raises(ValueError):
+    with pytest.raises(rti.Error):
        rtiConnectorFixture.getInput(invalid_DR)
 
   def test_creation_DR(self,rtiInputFixture):
@@ -60,3 +61,24 @@ class TestInput:
     get_name.restype = ctypes.c_char_p
     get_name.argtypes = [ctypes.c_void_p]
     assert rti.fromcstring(get_name(topic)) == "Square"
+
+  def test_no_autoenable(self):
+    with open_test_connector("MyParticipantLibrary::TestNoAutoenableSubscriber") as connector:
+      output = connector.get_output("TestPublisher::TestWriter")
+      connector.wait(1000) # TODO
+
+      # The input is not enabled yet because the subscriber sets
+      # autoenable_created_entities to false
+      output.instance['x'] = 1
+      output.write()
+
+      # Connector enables the DataReader when it's first looked up
+      input = connector.get_input("TestSubscriber::TestReader")
+      connector.wait(1000) # TODO wait for discovery
+      output.instance['x'] = 2
+      output.write()
+
+      # The input will receive only the second sample
+      wait_for_data(input)
+      assert input.sample_count == 1
+      assert input[0]['x'] == 2

--- a/test/python/test_rticonnextdds_output.py
+++ b/test/python/test_rticonnextdds_output.py
@@ -27,7 +27,7 @@ class TestOutput:
 
     """
     invalid_DW = "InvalidDW"
-    with pytest.raises(ValueError) as execinfo:
+    with pytest.raises(rti.Error) as execinfo:
       op= rtiConnectorFixture.get_output(invalid_DW)
     print("\nException of type:"+str(execinfo.type)+ \
       "\nvalue:"+str(execinfo.value))

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -11,6 +11,12 @@ import sys, os, pytest, threading, time
 sys.path.append(os.path.dirname(os.path.realpath(__file__))+ "/../../")
 import rticonnextdds_connector as rti
 
+def open_test_connector(config_name):
+    xml_path = os.path.join(
+      os.path.dirname(os.path.realpath(__file__)),
+      "../xml/TestConnector.xml")
+
+    return rti.open_connector(config_name, xml_path)
 
 def wait_for_data(input, count = 1, do_take = True):
   """Waits until input has count samples"""

--- a/test/xml/TestConnector.xml
+++ b/test/xml/TestConnector.xml
@@ -191,5 +191,27 @@ This code contains trade secrets of Real-Time Innovations, Inc.
                 <data_reader name="ReplyReader" topic_ref="Circle" />
             </subscriber>
         </domain_participant>
+
+        <domain_participant name="TestNoAutoenableSubscriber"
+                            domain_ref="MyDomainLibrary::MyDomain">
+            <subscriber name="TestSubscriber">
+                <subscriber_qos>
+                    <entity_factory>
+                        <autoenable_created_entities>false</autoenable_created_entities>
+                    </entity_factory>
+                </subscriber_qos>
+                <data_reader name="TestReader" topic_ref="Square">
+                    <datareader_qos>
+                        <durability>
+                            <kind>VOLATILE_DURABILITY_QOS</kind>
+                        </durability>
+                    </datareader_qos>
+                </data_reader>
+            </subscriber>
+
+            <publisher name="TestPublisher">
+                <data_writer name="TestWriter" topic_ref="Square" />
+            </publisher>
+        </domain_participant>
     </domain_participant_library>
 </dds>


### PR DESCRIPTION
Also changed how errors in entity creation are reported: they are an rti.Error now, and they include the C error messages