### PR TITLE
CON-125: Several updates to docs; made discovery methods properties

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.abspath('../rticonnextdds_connector'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'rticonnextdds-connector-py'
+project = 'RTI Connector for Python'
 copyright = '2019, RTI'
 author = 'RTI'
 

--- a/docs/connector.rst
+++ b/docs/connector.rst
@@ -43,6 +43,12 @@ and all its contained entities (*Topics*, *Subscribers*, *DataReaders*,
 For more information about the DDS entities, see `Part 2 - Core Concepts <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/index.htm#UsersManual/PartCoreConcepts.htm#partcoreconcepts_4109331811_915546%3FTocPath%3DPart%25202%253A%2520Core%2520Concepts%7C_____0>`__
 from the *RTI Connext DDS Core Libraries User's Manual*.
 
+.. note::
+
+  Operations on the same ``Connector`` instance or its contained entities are
+  not protected for multi-threaded access. See :ref:`Threading model` for more
+  information.
+
 Closing a *Connector*
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -135,7 +135,7 @@ To set any numeric type, including enumerations:
     output.instance.set_number("my_enum", 2)
 
 .. warning::
-    The range of values for a numeric field is determined by the integer type
+    The range of values for a numeric field is determined by the type
     used to define that field in the configuration file. However, ``set_number`` and
     ``get_number`` can't handle 64-bit integers (*int64* and *uint64*)
     whose absolute values are larger than 2^53. This is a *Connector* limitation
@@ -194,12 +194,12 @@ with numeric fields, returning the number as a string. For example:
 .. note::
     The typed getters and setters perform better than ``__setitem__``
     and ``__getitem__`` in applications that write or read at high rates.
-    Also ``__setitem__`` or ``__getitem__`` shouldn't be used as an alternative
-    to ``get_dictionary`` or ``set_dictionary`` when the intention is to access
-    most of the fields of the sample (see previous section).
+    Also prefer ``get_dictionary`` or ``set_dictionary`` over ``__setitem__``
+    or ``__getitem__`` when accessing all or most of the fields of a sample
+    (see previous section).
 
 .. note::
-    If a field ``my_string``, defined as a string in the configuration file contains
+    If a field *my_string*, defined as a string in the configuration file contains
     a value that can be interpreted as a number, ``sample["my_string"]`` returns
     a number, not a string.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,79 @@
+
+.. py:currentmodule:: rticonnextdds_connector
+
+Getting Started
+===============
+
+Installing RTI Connector for Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Make sure you have Python installed. Then use *pip* to install *RTI Connector*
+as follows:
+
+.. code:: bash
+
+   $ pip install rticonnextdds_connector
+
+You can also clone the repository:
+
+.. code:: bash
+
+   $ git clone --recursive https://github.com/rticommunity/rticonnextdds-connector-py.git
+
+Running the examples
+~~~~~~~~~~~~~~~~~~~~
+
+To run the examples, first clone the repository as indicated in the previous section,
+then run any of the python scripts in the ``examples/python`` directory:
+
+.. code:: bash
+
+    python examples/python/simple/reader.py
+
+On another shell:
+
+.. code:: bash
+
+    python examples/python/simple/writer.py
+
+This is how ``reader.py`` looks like:
+
+.. literalinclude:: ../examples/python/simple/reader.py
+    :lines: 19-
+
+
+And this is ``writer.py``:
+
+.. literalinclude:: ../examples/python/simple/writer.py
+    :lines: 17-
+
+To learn more about *RTI Connector* continue to the next section,
+:ref:`Using a Connector`.
+
+Supported Platforms
+~~~~~~~~~~~~~~~~~~~
+
+*RTI Connector* has been tested with Python 2.7.14 and 3.6.3.
+
+*RTI Connector* uses a native C library. It has been tested on the following
+platforms:
+
+- Windows (64-bit Windows 10 with VS 2015 and 32-bit Windows 7 with VS 2017)
+- Linux (64-bit CentOS 6.5 with gcc 4.8.2, 32-bit Ubuntu 16.04 gcc 5.4.0, and
+- MacOS (Darwin 18 clang 10)
+
+(TODO: link to main Connector landing page)
+
+*RTI Connector* is supported in other languages in addition to Python, see
+`main Connector
+repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
+
+License
+~~~~~~~
+
+With the sole exception of the contents of the “examples” subdirectory,
+all use of this product is subject to the RTI Software License Agreement
+included at the top level of this repository. Files within the
+“examples” subdirectory are licensed as marked within the file.
+
+(TODO: final license)

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -7,30 +7,39 @@ Getting Started
 Installing RTI Connector for Python
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Make sure you have Python installed. Then use *pip* to install *RTI Connector*
-as follows:
+There are two ways to obtain *RTI Connector* for Python. You can install it with
+*pip*:
 
 .. code:: bash
 
    $ pip install rticonnextdds_connector
 
-You can also clone the repository:
+And then run your *RTI Connector* applications:
+
+.. code:: bash
+
+    $ python my_connector_app.py
+
+You can also clone the repository and run the examples directly without installing
+*RTI Connector*:
 
 .. code:: bash
 
    $ git clone --recursive https://github.com/rticommunity/rticonnextdds-connector-py.git
 
+In order to gain access to the examples, clone the github repository.
+
 Running the examples
 ~~~~~~~~~~~~~~~~~~~~
 
-To run the examples, first clone the repository as indicated in the previous section,
-then run any of the python scripts in the ``examples/python`` directory:
+The examples are located in  the ``examples/python`` directory. To run the simple
+example:
 
 .. code:: bash
 
     python examples/python/simple/reader.py
 
-On another shell:
+In another shell:
 
 .. code:: bash
 
@@ -55,12 +64,15 @@ Supported Platforms
 
 *RTI Connector* has been tested with Python 2.7.14 and 3.6.3.
 
-*RTI Connector* uses a native C library. It has been tested on the following
-platforms:
+*RTI Connector* uses a native C library that works on most Windows, Linux and
+MacOS platforms. It has been tested on the following systems:
 
-- Windows (64-bit Windows 10 with VS 2015 and 32-bit Windows 7 with VS 2017)
-- Linux (64-bit CentOS 6.5 with gcc 4.8.2, 32-bit Ubuntu 16.04 gcc 5.4.0, and
-- MacOS (Darwin 18 clang 10)
+(TODO: clarify PAM)
+
+- Windows: 64-bit Windows 10 with VS 2015 and 32-bit Windows 7 with VS 2017
+- Linux: 64-bit CentOS 6.5 with gcc 4.8.2, 32-bit Ubuntu 16.04 gcc 5.4.0, and
+ARM Yocto Linux 2.0.3 with gcc 5.2.0
+- MacOS: Darwin 18 with clang 10
 
 (TODO: link to main Connector landing page)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,53 +1,38 @@
-.. rticonnextdds-connector-py documentation master file, created by
-   sphinx-quickstart on Wed Jul 10 14:57:26 2019.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. rticonnextdds-connector-py
+
 .. py:currentmodule:: rticonnextdds_connector
 
 RTI Connector for Python
 ========================
 
+RTI® Connext® DDS is a connectivity software framework for integrating data
+sources of all types. At its core is the world's leading ultra-high performance,
+distributed networking databus.
+
+*RTI Connector* provides a quick and easy way to write applications that
+publish and subscribe to the *RTI Connext DDS databus* in Python and other
+languages.
+
+You can learn how to use *RTI Connector* by reading the following sections, which
+include examples and detailed API reference. You can also find a specific type
+or function in the :ref:`genindex`.
+
+Table of Contents
+=================
+
 .. toctree::
    :maxdepth: 2
 
+   getting_started
    connector
    output
    input
    advanced
 
-Indices and tables
-==================
-
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`
 
-Getting Started
-===============
-
-RTI® Connext® DDS is a connectivity software framework for integrating data
-sources of all types. At its core is the world's leading ultra-high performance,
-distributed networking databus.
-
-*RTI Connector* provides a simplified API for the rapid development of
-applications that publish and subscribe to the *RTI Connext DDS databus*.
-
-In *RTI Connector*, you define your types, QoS profiles and DDS Entities in XML.
-Then you load the configuration using a Connector object (:ref:`Using a Connector`),
-which allows you to write to and read from DDS *Topics* (:ref:`Writing Data (Output)`,
-:ref:`Reading Data (Input)`).
-
-This documentation assumes you're familiar with *DDS*. For an overview,
-see `An Introduction to DDS <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_GettingStarted/index.htm#GettingStarted/An_Introduction_to_.htm#dds_2424438477_346722%3FTocPath%3D3.%2520A%25C2%25A0Quick%2520Overview%7C3.3%2520An%2520Introduction%2520to%2520DDS%7C_____0>`__
+You learn more about *RTI Connext DDS* in
+`An Introduction to DDS <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_GettingStarted/index.htm#GettingStarted/An_Introduction_to_.htm#dds_2424438477_346722%3FTocPath%3D3.%2520A%25C2%25A0Quick%2520Overview%7C3.3%2520An%2520Introduction%2520to%2520DDS%7C_____0>`__
 in the *RTI Connext DDS Core Libraries Getting Started Guide*. More documentation
-is available in the `RTI Community Portal <https://community.rti.com/documentation>`__
-
-This is the documentation of the *Python* binding. For other supported languages,
-see the `rticonnextdds-connector <https://github.com/rticommunity/rticonnextdds-connector>`__ repository.
-
-To get started with *RTI Connext DDS Connector for Python*,
-follow the installation instructions in the
-`rticonnextdds-connector-py <https://github.com/rticommunity/rticonnextdds-connector-py>`__ repository.
-
-
-
+is available in the `RTI Community Portal <https://community.rti.com/documentation>`__.

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -6,7 +6,7 @@ Reading data (Input)
 .. testsetup:: *
 
    import rticonnextdds_connector as rti
-   connector = rti.Connector("MyParticipantLibrary::MyParticipant", "ShapeExample.xml");
+   connector = rti.Connector("MyParticipantLibrary::MyParticipant", "ShapeExample.xml")
 
 
 Getting the input
@@ -16,7 +16,7 @@ To read/take samples, first get a reference to the :class:`Input`:
 
 .. testcode::
 
-   input = connector.get_input("MySubscriber::MySquareReader");
+   input = connector.get_input("MySubscriber::MySquareReader")
 
 :meth:`Connector.get_input()` returns a :class:`Input` object. This example,
 obtains the input defined by the *data_reader* named *MySquareReader* within
@@ -28,38 +28,6 @@ the *subscriber* named *MySubscriber*::
 
 This *subscriber* is defined inside the *domain_participant* selected to create
 this ``connector`` (see :ref:`Create a new *Connector*`).
-
-Matching with a Publication
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The method :meth:`Input.wait_for_publications()` can be used to detect when a compatible
-DDS publication is matched or unmatched. It returns the change in the number of
-matched publications since the last time it was called::
-
-   change_in_matches = Input.wait_for_publications()
-
-For example, if a new :class:`Output` was matched within the
-specified ``timeout``, the function would return 1. If, at a later point, this :class:`Output`
-left the network, a subsequent call to :meth:`Input.wait_for_publications()` would return
--1.
-The optional ``timeout`` argument can be used to specify the maximum amount of time in
-milliseconds to wait for a new match. If no match is found within the ``timeout``, :class:`TimeoutError`
-is raised. By default the timeout is infinite.
-
-
-In order to ascertain whether or not an :class:`Input` is matched with a specific :class:`Output`, you
-should use the :meth:`Input.get_matched_publications()` method. This method returns a list
-of the *Publication Names* of all of the matched :class:`Output`.
-
-.. testcode::
-
-   matched_outputs = input.get_matched_publications()
-
-.. note::
-    The list returned will contain the name of each matched publication.
-    If one of them didn't specify a name, the list will contain a None element
-    instead. In any case, the size of the list reflects the current number of
-    matched publication.
 
 Reading or taking the data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -160,6 +128,27 @@ You can access a field of the sample meta-data, the *SampleInfo*, as follows:
 
 
 See :meth:`SampleIterator.info` for the list of meta-data fields available
+
+Matching with a Publication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The method :meth:`Input.wait_for_publications()` can be used to detect when a compatible
+DDS publication is matched or stops matching. It returns the change in the number of
+matched publications since the last time it was called::
+
+   change_in_matches = Input.wait_for_publications()
+
+For example, if a new compatible publication is discovered within the specified
+``timeout``, the function returns 1.
+
+You can obtain information about the existing matched publications with
+:attr:`Input.matched_publication`:
+
+.. testcode::
+
+   matched_pubs = input.matched_publications
+   for pub_info in matched_pubs:
+      pub_name = pub_info['name']
 
 Class reference: Input, SampleIterator, ValidSampleIterator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -136,7 +136,7 @@ The method :meth:`Input.wait_for_publications()` can be used to detect when a co
 DDS publication is matched or stops matching. It returns the change in the number of
 matched publications since the last time it was called::
 
-   change_in_matches = Input.wait_for_publications()
+   change_in_matches = input.wait_for_publications()
 
 For example, if a new compatible publication is discovered within the specified
 ``timeout``, the function returns 1.

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -7,12 +7,12 @@ Writing data (Output)
 .. testsetup:: *
 
    import rticonnextdds_connector as rti
-   connector = rti.Connector("MyParticipantLibrary::MyParticipant", "ShapeExample.xml");
+   connector = rti.Connector("MyParticipantLibrary::MyParticipant", "ShapeExample.xml")
 
 Getting the Output
 ~~~~~~~~~~~~~~~~~~
 
-To write a data sample, first get a reference to the output port:
+To write a data sample, first look up an output:
 
 .. testcode::
 
@@ -59,38 +59,6 @@ For example::
 
 See :class:`Instance` and :ref:`Accessing the data` for more information.
 
-Matching with a Subscription
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The method :meth:`Output.wait_for_subscriptions()` can be used to detect when a compatible
-DDS subscription is matched or unmatched. It returns the change in the number of
-matched subscriptions since the last time it was called::
-
-   change_in_matches = Output.wait_for_subscriptions()
-
-For example, if a new :class:`Input` was matched within the
-specified ``timeout``, the function would return 1. If, at a later point, this :class:`Input`
-left the network, a subsequent call to :meth:`Output.wait_for_subscriptions()` would return
--1.
-The optional ``timeout`` argument can be used to specify the maximum amount of time in
-milliseconds to wait for a new match. If no match is found within the ``timeout``, :class:`TimeoutError`
-is raised. By default the timeout is infinite.
-
-
-In order to ascertain whether or not an :class:`Output` is matched with a specific :class:`Input`, you
-should use the :meth:`Output.get_matched_subscriptions()` method. This method returns a list
-of the *Subscription Names* of all of the matched :class:`Input`.
-
-.. testcode::
-
-   matched_inputs = output.get_matched_subscriptions()
-
-.. note::
-    The list returned will contain the name of each matched subscription.
-    If one of them didn't specify a name, the list will contain a None element
-    instead. In any case, the size of the list reflects the current number of
-    matched subscriptions.
-
 Writing the data sample
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -110,6 +78,27 @@ write with a specific timestamp:
 .. testcode::
 
   output.write(source_timestamp=100000)
+
+Matching with a Subscription
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before writing, the method :meth:`Output.wait_for_subscriptions()` can be used to
+detect when a compatible DDS subscription is matched or stops matching. It returns
+the change in the number of matched subscriptions since the last time it was called::
+
+   change_in_matches = output.wait_for_subscriptions()
+
+For example, if a new compatible subscription is discovered within the specified
+``timeout``, the function returns 1.
+
+You can obtain information about the existing matched subscriptions with
+:attr:`Output.matched_subscriptions`:
+
+.. testcode::
+
+   matched_subs = output.matched_subscriptions
+   for sub_info in matched_subs:
+    sub_name = sub_info['name']
 
 Class reference: Output, Instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -729,8 +729,20 @@ class Input:
 		_check_retcode(retcode)
 		return current_count_change.value
 
-	def get_matched_publications(self):
-		"""Returns a JSON list of the publication names of all matched outputs"""
+	@property
+	def matched_publications(self):
+		"""Returns information about the matched publications
+
+		This property returns a list where each element is a dictionary with
+		information about a publication matched with this Input.
+
+		Currently, the only key in the dictionaries is ``"name"``,
+		containing the publication name. If a publication doesn't have name,
+		the value for the key ``name`` is ``None``.
+
+		Note that Connector Outputs are automatically assigned a name from the
+		*data_writer name* in the XML configuration.
+		"""
 		native_json_str = ctypes.c_char_p()
 		retcode = connector_binding.get_matched_publications(self.native, byref(native_json_str))
 		_check_retcode(retcode)
@@ -1024,7 +1036,7 @@ class Output:
 
 		This method receives a number of optional parameters, a subset of those
 		documented in the `Writing Data section <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/index.htm#UsersManual/Writing_Data.htm?Highlight=DDS_WriteParams_t>`__. 
-		of the *Connext DDS Core Libraries** User's Manual.
+		of the *Connext DDS Core Libraries* User's Manual.
 
 		The supported parameters are:
 
@@ -1038,6 +1050,10 @@ class Output:
 				identity={"writer_guid":[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], "sequence_number":1},
 				timestamp=1000000000)
 
+		The write method can block under multiple circumstances (see
+		*Blocking During a write()* in the *Connext DDS Core Libraries* User's
+		Manual). If the blocking time exceeds the *max_blocking_time*, this
+		method raises :class:`TimeoutError`.
 		"""
 
 		if len(kwargs) > 0:
@@ -1068,13 +1084,15 @@ class Output:
 		_check_retcode(retcode)
 
 	def wait_for_subscriptions(self, timeout = None):
-		"""Waits until this output matches or unmatches with a compatible DDS subscription.
+		"""Waits until the number of matched DDS subscription changes
 
-		If the operation times out, it will raise :class:`TimeoutError`.
+		This method waits until new compatible subscriptions are discovered or
+		existing subscriptions no longer match.
 
 		:param number timeout: The maximum time to wait in milliseconds. By default, infinite.
-
 		:return: The change in the current number of matched outputs. If a positive number is returned, the input has matched with new publishers. If a negative number is returned the input has unmatched from an output. It is possible for multiple matches and/or unmatches to be returned (e.g., 0 could be returned, indicating that the input matched the same number of writers as it unmatched).
+
+		This method raises :class:`TimeoutError` if the ``timeout`` elapses.
 
 		"""
 		if timeout is None:
@@ -1084,8 +1102,21 @@ class Output:
 		_check_retcode(retcode)
 		return current_count_change.value
 
-	def get_matched_subscriptions(self):
-		"""Returns a JSON list of the subscription names of all matched inputs"""
+	@property
+	def matched_subscriptions(self):
+		"""Returns information about the matched subscriptions
+
+		This property returns a list where each element is a dictionary with
+		information about a subscription matched with this Output.
+
+		Currently, the only key in the dictionaries is ``"name"``,
+		containing the subscription name. If a subscription doesn't have name,
+		the value is ``None``.
+
+		Note that Connector Inputs are automatically assigned a name from the
+		*data_reader name* in the XML configuration.
+		"""
+
 		native_json_str = ctypes.c_char_p()
 		retcode = connector_binding.get_matched_subscriptions(self.native, byref(native_json_str))
 		_check_retcode(retcode)

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -12,7 +12,7 @@ To use this package, import it as follows::
 
    import rticonnextdds_connector as rti
 
-The entry point is the class :class:`Connector`, which creates :class:`Input` 
+The entry point is the class :class:`Connector`, which creates :class:`Input`
 and :class:`Output` objects.
 """
 
@@ -691,7 +691,7 @@ class Input:
 		"""Accesses the sample received by this Input
 
 		After calling this method, the samples are accessible with
-		:attr:`data_iterator`, :attr:`valid_data_iterator`, 
+		:attr:`data_iterator`, :attr:`valid_data_iterator`,
 		or :meth:`get_sample()`.
 
 		"""
@@ -793,8 +793,8 @@ class Input:
 		This iterator may return samples with invalid data. Use :attr:`valid_data_iterator`
 		to access only samples with valid data.
 
-		The `Input` class also provides ``__iter__``, making it possible to 
-		interchangeably write ``for sample in input`` or 
+		The `Input` class also provides ``__iter__``, making it possible to
+		interchangeably write ``for sample in input`` or
 		``for sample in input.data_iterator``.
 
 		:return: An iterator to the samples
@@ -1035,7 +1035,7 @@ class Output:
 		:meth:`clear_members()`
 
 		This method receives a number of optional parameters, a subset of those
-		documented in the `Writing Data section <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/index.htm#UsersManual/Writing_Data.htm?Highlight=DDS_WriteParams_t>`__. 
+		documented in the `Writing Data section <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/index.htm#UsersManual/Writing_Data.htm?Highlight=DDS_WriteParams_t>`__.
 		of the *Connext DDS Core Libraries* User's Manual.
 
 		The supported parameters are:
@@ -1126,10 +1126,10 @@ class Output:
 		"""Resets the values of the members of this ``Output.instance``
 
 		If the member is defined with the ``default`` attribute in the configuration
-		file, it gets that value. Otherwise numbers are set to 0, and strings 
+		file, it gets that value. Otherwise numbers are set to 0, and strings
 		are set to empty. Sequences are cleared. Optional members are set to ``None``.
 
-		For example, if this ``Output``'s type is `ShapeType` (from the previous 
+		For example, if this ``Output``'s type is `ShapeType` (from the previous
 		example), then ``clear_members()`` sets `color` to "RED", `shapesize`
 		to 30, and `x` and `y` to 0.
 		"""
@@ -1152,18 +1152,18 @@ class Connector:
 
 	A ``Connector`` instance must be deleted with :meth:`close()`.
 
-	:param str configName: The configuration to load. 	The ``configName`` format is ``"LibraryName::ParticipantName"``, where ``LibraryName`` is the ``name`` attribute of a ``<domain_participant_library>`` tag, and ``ParticipantName`` is the ``name`` attribute of a ``<domain_participant>`` tag inside the library.
+	:param str config_name: The configuration to load. 	The ``config_name`` format is ``"LibraryName::ParticipantName"``, where ``LibraryName`` is the ``name`` attribute of a ``<domain_participant_library>`` tag, and ``ParticipantName`` is the ``name`` attribute of a ``<domain_participant>`` tag inside the library.
 	:param str url: An URL locating the XML document. The ``url`` can be a file path (for example, ``'/tmp/my_dds_config.xml'``) or a string containing the full XML document with the following format ``'str://"<dds>...</dds>"'``)
 
 	"""
 
-	def __init__(self, configName, url):
+	def __init__(self, config_name, url):
 		# enable data event (default), 0-based seq indexing
 		options = _ConnectorOptions(
 			enable_on_data_event = 1,
 			one_based_sequence_indexing = 0)
 		self.native = connector_binding.new(
-			tocstring(configName),
+			tocstring(config_name),
 			tocstring(url),
 			ctypes.byref(options))
 		_check_entity_creation(self.native, "Connector")
@@ -1260,7 +1260,7 @@ class Connector:
 		_check_retcode(retcode)
 
 @contextmanager
-def open_connector(configName, url):
+def open_connector(config_name, url):
 	"""A resource manager that creates and deletes a Connector
 
 	It takes the sames arguments as the :class:`Connector` class::
@@ -1271,7 +1271,7 @@ def open_connector(configName, url):
 		# connector closed after with block exits
 	"""
 
-	connector = Connector(configName, url)
+	connector = Connector(config_name, url)
 	try:
 		yield connector
 	finally:

--- a/test/python/test_rticonnextdds_discovery.py
+++ b/test/python/test_rticonnextdds_discovery.py
@@ -70,7 +70,7 @@ class TestDiscovery:
 
   def test_no_matches_input(self, discovery_reader_only_input):
     # We should not match with any outputs at this point
-    matches = discovery_reader_only_input.get_matched_publications()
+    matches = discovery_reader_only_input.matched_publications
     assert len(matches) == 0
 
     # We should timeout if we attempt to wait for a match
@@ -80,7 +80,7 @@ class TestDiscovery:
 
   def test_no_matches_output(self, discovery_writer_only_output):
     # We should not match with any outputs at this point
-    matches = discovery_writer_only_output.get_matched_subscriptions()
+    matches = discovery_writer_only_output.matched_subscriptions
     assert len(matches) == 0
 
     # We should timeout if we attempt to wait for a match
@@ -93,12 +93,12 @@ class TestDiscovery:
 
     # Both the input and output should match each other (and nothing else)
     change_in_matches = the_input.wait_for_publications(2000)
-    matches = the_input.get_matched_publications()
+    matches = the_input.matched_publications
     assert change_in_matches == 1
     assert isinstance(matches, list)
     assert {'name': 'MyWriter'} in matches
     change_in_matches = the_output.wait_for_subscriptions(2000)
-    matches = the_output.get_matched_subscriptions()
+    matches = the_output.matched_subscriptions
     assert change_in_matches == 1
     assert isinstance(matches, list)
     assert {'name': 'MyReader'} in matches
@@ -117,7 +117,7 @@ class TestDiscovery:
     with pytest.raises(rti.TimeoutError) as excinfo:
       the_output.wait_for_subscriptions(1000)
 
-    matches = the_output.get_matched_subscriptions()
+    matches = the_output.matched_subscriptions
     assert {'name': 'MyReader'} in matches
     assert {'name': 'TestReader'} in matches
 
@@ -135,7 +135,7 @@ class TestDiscovery:
     with pytest.raises(rti.TimeoutError) as excinfo:
       the_input.wait_for_publications(1000)
 
-    matches = the_input.get_matched_publications()
+    matches = the_input.matched_publications
     assert {'name': 'MyWriter'} in matches
     assert {'name': 'TestWriter'} in matches
 
@@ -144,7 +144,7 @@ class TestDiscovery:
   # test function
   def test_unmatched_input(self, discovery_writer_only_output):
     # To begin with, no matching occurs
-    assert len(discovery_writer_only_output.get_matched_subscriptions()) == 0
+    assert len(discovery_writer_only_output.matched_subscriptions) == 0
 
     # Create the Connector object containing the matching input
     reader_connector = rti.Connector(
@@ -156,11 +156,11 @@ class TestDiscovery:
     # Check that matching occurs
     change_in_matches = discovery_writer_only_output.wait_for_subscriptions(5000)
     assert change_in_matches == 1
-    matches = discovery_writer_only_output.get_matched_subscriptions()
+    matches = discovery_writer_only_output.matched_subscriptions
     assert {'name': 'TestReader'} in matches
     change_in_matches = the_input.wait_for_publications(5000)
     assert change_in_matches == 1
-    matches = the_input.get_matched_publications()
+    matches = the_input.matched_publications
     assert {'name': 'TestWriter'} in matches
 
     # If we now delete the reader_connector object which we created above, they
@@ -168,7 +168,7 @@ class TestDiscovery:
     reader_connector.close()
     change_in_matches = discovery_writer_only_output.wait_for_subscriptions(5000)
     assert change_in_matches == -1
-    matches = discovery_writer_only_output.get_matched_subscriptions()
+    matches = discovery_writer_only_output.matched_subscriptions
     assert len(matches) == 0
 
   # Even though we are going to use the discovery_writer_only_output, don't use the
@@ -176,7 +176,7 @@ class TestDiscovery:
   # test function
   def test_unmatched_output(self, discovery_reader_only_input):
     # To begin with, no matching occurs
-    assert len(discovery_reader_only_input.get_matched_publications()) == 0
+    assert len(discovery_reader_only_input.matched_publications) == 0
 
     # Create the Connector object containing the matching input
     writer_connector = rti.Connector(
@@ -188,11 +188,11 @@ class TestDiscovery:
     # Check that matching occurs
     change_in_matches = discovery_reader_only_input.wait_for_publications()
     assert change_in_matches == 1
-    matches = discovery_reader_only_input.get_matched_publications()
+    matches = discovery_reader_only_input.matched_publications
     assert {'name': 'TestWriter'} in matches
     change_in_matches = the_output.wait_for_subscriptions(5000)
     assert change_in_matches == 1
-    matches = the_output.get_matched_subscriptions()
+    matches = the_output.matched_subscriptions
     assert {'name': 'TestReader'} in matches
 
     # If we now delete the reader_connector object which we created above, they
@@ -200,7 +200,7 @@ class TestDiscovery:
     writer_connector.close()
     change_in_matches = discovery_reader_only_input.wait_for_publications(5000)
     assert change_in_matches == -1
-    matches = discovery_reader_only_input.get_matched_publications()
+    matches = discovery_reader_only_input.matched_publications
     assert len(matches) == 0
 
   def test_empty_entity_names(self, discovery_connector_no_entity_names):
@@ -210,7 +210,7 @@ class TestDiscovery:
     assert change_in_subs == 1
 
     # Get the entity names from the matched subscriptions
-    matched_subs = the_output.get_matched_subscriptions()
+    matched_subs = the_output.matched_subscriptions
     # The entity names set in the input are empty
     assert matched_subs == [{'name': ''}]
 
@@ -226,12 +226,12 @@ class TestDiscovery:
     # Wait to match with the new reader
     discovery_writer_only_output.wait_for_subscriptions(5000)
     # Check that we can handle getting entity_name when it is NULL
-    matches = discovery_writer_only_output.get_matched_subscriptions()
+    matches = discovery_writer_only_output.matched_subscriptions
     assert isinstance(matches, list)
     assert len(matches) == 1
     assert isinstance(matches[0], dict)
     assert matches[0]['name'] is None
 
-    # It is not necessary to delete the entites created by the call to createTestScenario
+    # It is not necessary to delete the entities created by the call to createTestScenario
     # since they were all created from the same DomainParticipant as discovery_writer_only_output
     # which will have delete_contained_entities called on it.

--- a/test/python/test_rticonnextdds_input.py
+++ b/test/python/test_rticonnextdds_input.py
@@ -73,5 +73,5 @@ class TestInput:
       # Connector enables the DataReader when it's first looked up
       input = connector.get_input("TestSubscriber::TestReader")
       output.wait_for_subscriptions(5000)
-      matched_subs = output.get_matched_subscriptions()
+      matched_subs = output.matched_subscriptions
       assert {"name":"TestReader"} in matched_subs


### PR DESCRIPTION
* Improve threading.rst
* Discovery functions: move some details from rst files to function documentation, so that the rst deals with the most common use case only
* The discovery section in the rst is now after write/read, since waiting/looking up discovery is less important and is optional
* get_matched_publications/subscriptions are now properties instead of methods
* Update doc of write() to indicate that can raise TimeoutError
* Other minor improvemenets