### PR TITLE
CON-100: Enable test after DynamicData fix, disable 3 tests that won'…

### DIFF
--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -236,13 +236,10 @@ class TestDataAccess:
     sample = populated_input[0]
     assert sample.get_number("my_optional_point.x") is None
 
-  @pytest.mark.xfail
   def test_unset_complex_optional_dict2(self, populated_input):
     sample = populated_input[0]
     assert sample.get_number("my_optional_point.x") is None
     dictionary = sample.get_dictionary()
-    # Due to CORE-9685 the previous call to get_number "initializes"
-    # my_optional_point, so get_dictionary now incorrectly returns it
     assert not "my_optional_point" in dictionary
 
   def test_reset_optional_number(self, test_output, test_input):
@@ -484,6 +481,7 @@ class TestDataAccess:
     # largest long long
     self.verify_large_integer(test_output, test_input, 2**63 - 1)
 
+  @pytest.mark.xfail(sys.platform.startswith("win"), reason="symbols not exported")
   def test_access_input_native_dynamic_data(self, populated_input):
     get_member_count = rti.connector_binding.library.DDS_DynamicData_get_member_count
     get_member_count.restype = ctypes.c_uint
@@ -491,6 +489,7 @@ class TestDataAccess:
     count = get_member_count(populated_input[0].native)
     assert count > 0
 
+  @pytest.mark.xfail(sys.platform.startswith("win"), reason="symbols not exported")
   def test_access_output_native_dynamic_data(self, test_output, test_dictionary):
     test_output.instance.set_dictionary(test_dictionary)
     get_member_count = rti.connector_binding.library.DDS_DynamicData_get_member_count

--- a/test/python/test_rticonnextdds_input.py
+++ b/test/python/test_rticonnextdds_input.py
@@ -51,6 +51,7 @@ class TestInput:
       and isinstance(rtiInputFixture.samples,rti.Samples) \
       and isinstance(rtiInputFixture.infos,rti.Infos)
 
+  @pytest.mark.xfail(sys.platform.startswith("win"), reason="symbols not exported")
   def test_reader_native_call(self, rtiInputFixture):
     get_topic = rti.connector_binding.library.DDS_DataReader_get_topicdescription
     get_topic.restype = ctypes.c_void_p

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -23,6 +23,7 @@ def wait_for_data(input, count = 1, do_take = True):
 
   for i in range(1, 5):
     input.read()
+    assert input.sample_count <= count
     if input.sample_count == count:
       break
     input.wait(1000)


### PR DESCRIPTION
…t work on Windows

The connector dll on windows doesn't export dds_c symbols, so we can't directly access the C API if it hasn't been exposed in the connector dll. See CON-73 for more info.