### PR TITLE
CON-129: Support passing None in SampleIterator.__setitem__ to clear …

### DIFF
--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -875,6 +875,8 @@ class Instance:
 			self.set_string(field_name, value)
 		elif isinstance(value, bool):
 			self.set_boolean(field_name, value)
+		elif value is None:
+			self.clear_member(field_name)
 		else:
 			raise TypeError("'{0}' is not a valid type for 'value'".format(type(value).__name__))
 

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -691,3 +691,8 @@ class TestDataAccess:
     with pytest.raises(rti.Error) as excinfo:
       # sequence max length is 10
       test_output.instance.set_dictionary({"my_int_sequence":[10] * 11})
+
+  def test_clear_member_with_setitem(self, test_output, test_input):
+    test_output.instance['my_optional_bool'] = None
+    sample = send_data(test_output, test_input)
+    assert sample['my_optional_bool'] is None


### PR DESCRIPTION
…a member