### PR TITLE
CON-214: Added test for creating Connector with participant_qos

### DIFF
--- a/test/python/test_rticonnextdds_connector.py
+++ b/test/python/test_rticonnextdds_connector.py
@@ -91,3 +91,17 @@ class TestConnector:
             assert connector is not None
             output = connector.get_output("MyPublisher2::MySquareWriter2")
             assert output is not None
+
+    def test_connector_creation_with_participant_qos(self):
+        """
+        Tests that a domain_participant defined in XML alonside participant_qos
+        can be used to create a Connector object.
+        """
+        participant_profile = "MyParticipantLibrary::ConnectorWithParticipantQos"
+        xml_path = os.path.join(os.path.dirname(
+                os.path.realpath(__file__)),
+                "../xml/TestConnector.xml")
+        with rti.open_connector(
+                config_name=participant_profile,
+                url=xml_path) as connector:
+            assert connector is not None

--- a/test/xml/TestConnector.xml
+++ b/test/xml/TestConnector.xml
@@ -394,5 +394,11 @@ This code contains trade secrets of Real-Time Innovations, Inc.
                 </data_writer>
             </publisher>
         </domain_participant>
+
+        <!-- Test for CON-214 -->
+        <domain_participant name="ConnectorWithParticipantQos"
+                            domain_ref="MyDomainLibrary::MyDomain">
+            <participant_qos/>
+        </domain_participant>
     </domain_participant_library>
 </dds>


### PR DESCRIPTION
@alexcamposruiz Confirmed that this test currently fails. Tested it with a librtiddsconnectord.so from develop (containing some initial changes in a feature branch to address this bug) and it passes.