### PR TITLE
Introduce EOL normalisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 LICENSE.pdf filter=lfs diff=lfs merge=lfs -text
+* text=auto


### PR DESCRIPTION
With this, License.pdf should not longer show up as changed on Windows