### PR TITLE
GREEN-2058: Fixed string checking when setting invalid my_enum from dict

### DIFF
--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -685,11 +685,16 @@ class TestDataAccess:
     # For each numeric field, test that set_dictionary fails when the value we
     # try to set is a string that doesn't represent a number
     field_names = ["my_long", "my_int64", "my_double",
-      "my_point_array[1].x", "my_int_sequence[1]", "my_enum", "my_uint64"]
+      "my_point_array[1].x", "my_int_sequence[1]", "my_uint64"]
     for name in field_names:
         with pytest.raises(rti.Error, match=r".*cannot convert field to string.*") as excinfo:
           test_output.instance.set_dictionary({name:"not a number"})
           print("Field " + name + " did not raise an exception")
+    # For enums, the error printed is slightly different
+    with pytest.raises(rti.Error, match=r".*convert enum string to numerical representation.*") as excinfo:
+        test_output.instance.set_dictionary({"my_enum":"not a number"})
+        print("Field my_enum did not raise an exception")
+
 
   def test_error_in_dictionary(self, test_output, test_input):
     with pytest.raises(rti.Error) as excinfo:


### PR DESCRIPTION
Changes required after Antonio's fix in native libs.