### PR TITLE
HERCULES-186: updates to licenses doc for python

### DIFF
--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -61,11 +61,8 @@ Website: https://support.rti.com/ |br|
 .. rubric:: External Third-Party Software Used in Connector
 
 **Lua**
-  * This software is shipped as part of the native libraries provided by 
-    *RTI Connector*.
-
-  * We have the source code checked into the connextdds repository in the 
-    lua.1.0 module (version 5.2).
+  * The source code of this software is used to build the native libraries
+    provided by *RTI Connector*.
 
   * License (https://www.lua.org/license.html):
     Copyright © 1994–2021 Lua.org, PUC-Rio.
@@ -89,11 +86,8 @@ Website: https://support.rti.com/ |br|
     THE SOFTWARE.
 
 **json-parser**
-  * This software is shipped as part of the native libraries provided by 
-    *RTI Connector*.
-
-  * We have the source code checked into the connextdds repository in the 
-    json.1.0 module (from https://github.com/udp/json-parser)
+  * The source code of this software (from https://github.com/udp/json-parser) 
+    is used to build the native libraries provided by *RTI Connector*.
 
   * License:
 

--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -57,3 +57,68 @@ Email: support@rti.com |br|
 Website: https://support.rti.com/ |br|
 
 © 2021 RTI
+
+.. rubric:: External Third-Party Software Used in Connector
+
+**Lua**
+  * This software is shipped as part of the native libraries provided by 
+    *RTI Connector*.
+
+  * We have the source code checked into the connextdds repository in the 
+    lua.1.0 module (version 5.2).
+
+  * License (https://www.lua.org/license.html):
+    Copyright © 1994–2021 Lua.org, PUC-Rio.
+
+    Permission is hereby granted, free of charge, to any person obtaining a 
+    copy of this software and associated documentation files (the "Software"), 
+    to deal in the Software without restriction, including without limitation 
+    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+    and/or sell copies of the Software, and to permit persons to whom the 
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included 
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+    THE SOFTWARE.
+
+**json-parser**
+  * This software is shipped as part of the native libraries provided by 
+    *RTI Connector*.
+
+  * We have the source code checked into the connextdds repository in the 
+    json.1.0 module (from https://github.com/udp/json-parser)
+
+  * License:
+
+    Copyright (C) 2012, 2013, 2014 James McLaughlin et al.  All rights reserved.
+    https://github.com/udp/json-parser
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.


### PR DESCRIPTION
required by Legal (they don't care where we put it as long as it's in there)