### PR TITLE
CON-92: Added the ability to obtain current version of Connector

### DIFF
--- a/docs/connector.rst
+++ b/docs/connector.rst
@@ -102,9 +102,3 @@ Class reference: Connector
    :members:
 
 .. autofunction:: rticonnextdds_connector.open_connector
-
-Class reference: ConnectorVersion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: rticonnextdds_connector.ConnectorVersion
-   :members:

--- a/docs/connector.rst
+++ b/docs/connector.rst
@@ -102,3 +102,9 @@ Class reference: Connector
    :members:
 
 .. autofunction:: rticonnextdds_connector.open_connector
+
+Class reference: ConnectorVersion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: rticonnextdds_connector.ConnectorVersion
+   :members:

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -413,12 +413,14 @@ class ConnectorVersion:
 
     # This internal method converts an instance of _NativeConnectorVersion into
     # an instance of ConnectorVersion.
-    def _from_native(self, native):
-        self.major = ord(native.major)
-        self.minor = ord(native.minor)
-        self.release = ord(native.release)
-        self.revision = ord(native.revision)
-        return self
+    @staticmethod
+    def _from_native(native):
+        version = ConnectorVersion()
+        version.major = ord(native.major)
+        version.minor = ord(native.minor)
+        version.release = ord(native.release)
+        version.revision = ord(native.revision)
+        return version
 
     # overload __str__, which is called internally when str() is used
     def __str__(self):
@@ -1434,8 +1436,7 @@ class Connector:
         :rtype: :class:`ConnectorVersion`
         """
         nativeVersionPtr = connector_binding.get_library_version()
-        libVersion = ConnectorVersion()
-        return libVersion._from_native(nativeVersionPtr.contents)
+        return ConnectorVersion._from_native(nativeVersionPtr.contents)
 
     @staticmethod
     def version():

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -393,14 +393,12 @@ class _ConnectorOptions(ctypes.Structure):
 class ConnectorVersion:
     """This class provides information about the version of Connector being used.
 
-        An instance of this class is returned by the
-        ``Connector.native_library_version`` method, in which case it will contain
-        information regarding the release of the native Connext DDS Pro libraries
-        being used by Connector (e.g., 6.1.0).
+        An instance of this class is returned by :meth:`Connector.native_library_version`,
+        in which case it will contain information regarding the release of the
+        native Connext DDS Pro libraries being used by Connector (e.g., 6.1.0).
 
-        An instance of this class is also returned by the ``Connector.version``
-        method, providing information regarding the release of Connector (e.g.,
-        1.1.0).
+        An instance of this class is also returned by :meth:`Connector.version`,
+        providing information regarding the release of Connector (e.g., 1.1.0).
 
         This class provides the version using 4 integer values. For example,
         the 1.1.0 release of connector would be returned as major = 1, minor = 1,
@@ -1425,6 +1423,7 @@ class Connector:
         """Returns the build ID of the native libraries as a string
 
         :return: The build ID of the native libraries used by Connector.
+        :rtype: string
         """
         return fromcstring(connector_binding.get_build_string())
 

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -1371,7 +1371,7 @@ class Connector:
         _check_retcode(connector_binding.set_max_objects_per_thread(value))
 
     @staticmethod
-    def version():
+    def get_version():
         """
         Returns the version of Connector.
 

--- a/test/python/test_rticonnextdds_connector.py
+++ b/test/python/test_rticonnextdds_connector.py
@@ -8,10 +8,10 @@
 
 import sys
 import os
+import re
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../")
 import rticonnextdds_connector as rti
 import pytest
-sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../")
-
 
 class TestConnector:
     """
@@ -94,7 +94,7 @@ class TestConnector:
 
     def test_connector_creation_with_participant_qos(self):
         """
-        Tests that a domain_participant defined in XML alonside participant_qos
+        Tests that a domain_participant defined in XML alongside participant_qos
         can be used to create a Connector object.
         """
         participant_profile = "MyParticipantLibrary::ConnectorWithParticipantQos"
@@ -105,3 +105,103 @@ class TestConnector:
                 config_name=participant_profile,
                 url=xml_path) as connector:
             assert connector is not None
+
+    def test_native_library_version_getter(self):
+        """
+        native_library_version is a static method that can be can be called
+        either before or after the creation of a Connector instance. It
+        returns a structure containing the release of the native libraries.
+        """
+        # Ensure that we can call native_library_version before creating an
+        # instance of Connector
+        native_library_version = rti.Connector.native_library_version()
+        assert native_library_version is not None
+        assert isinstance(native_library_version, rti.ConnectorVersion)
+
+        # The returned version should contain a major, minor, release and revision
+        # field
+        assert isinstance(native_library_version.major, int)
+        assert isinstance(native_library_version.minor, int)
+        assert isinstance(native_library_version.release, int)
+        assert isinstance(native_library_version.revision, int)
+
+        # Create an instance of Connector and call the method again
+        participant_profile = "MyParticipantLibrary::ConnectorWithParticipantQos"
+        xml_path = os.path.join(os.path.dirname(
+                os.path.realpath(__file__)),
+                "../xml/TestConnector.xml")
+        with rti.open_connector(
+                config_name=participant_profile,
+                url=xml_path) as connector:
+            assert connector is not None
+            native_library_version2 = connector.native_library_version()
+            assert native_library_version2 is not None
+            assert isinstance(native_library_version2, rti.ConnectorVersion)
+
+        # Check that the str() method converts the ConnectorVersion class
+        # into the correct format (e.g., 6.1.0.0)
+        version_str = str(native_library_version)
+        assert bool(re.match("[0-9]\\.[0-9]\\.[0-9]\\.[0-9]", version_str)) == True
+
+    def test_version_getter(self):
+        """
+        Connector.version is a static method that can be can be called
+        either before or after the creation of a Connector instance. It
+        returns a structure containing information about the release of Connector
+        in use.
+        """
+        # Ensure that we can call native_library_version before creating an
+        # instance of Connector
+        version = rti.Connector.version()
+        assert version is not None
+        assert isinstance(version, rti.ConnectorVersion)
+
+        # The returned version should contain a major, minor, release and revision
+        # field
+        assert isinstance(version.major, int)
+        assert isinstance(version.minor, int)
+        assert isinstance(version.release, int)
+        assert isinstance(version.revision, int)
+
+        # Create an instance of Connector and call the method again
+        participant_profile = "MyParticipantLibrary::ConnectorWithParticipantQos"
+        xml_path = os.path.join(os.path.dirname(
+                os.path.realpath(__file__)),
+                "../xml/TestConnector.xml")
+        with rti.open_connector(
+                config_name=participant_profile,
+                url=xml_path) as connector:
+            assert connector is not None
+            version2 = connector.version()
+            assert version2 is not None
+            assert isinstance(version2, rti.ConnectorVersion)
+
+        # Check that the str() method converts the ConnectorVersion class
+        # into the correct format (e.g., "1.1.0.0")
+        version_str = str(version)
+        assert bool(re.match("[0-9]\\.[0-9]\\.[0-9]\\.[0-9]", version_str)) == True
+
+    def test_build_string_getter(self):
+
+        """
+        Connector.native_build_string is a static method that can be can be called
+        either before or after the creation of a Connector instance. It
+        returns a string containing information about the release of native
+        libraries being used by Connector.
+        """
+        build_str = rti.Connector.native_library_build_string()
+        assert build_str is not None
+        assert isinstance(build_str, str)
+
+        # Create an instance of Connector and call the method again
+        participant_profile = "MyParticipantLibrary::ConnectorWithParticipantQos"
+        xml_path = os.path.join(os.path.dirname(
+                os.path.realpath(__file__)),
+                "../xml/TestConnector.xml")
+        with rti.open_connector(
+                config_name=participant_profile,
+                url=xml_path) as connector:
+            assert connector is not None
+            build_str2 = rti.Connector.native_library_build_string()
+            assert build_str2 is not None
+            assert isinstance(build_str2, str)

--- a/test/python/test_rticonnextdds_connector.py
+++ b/test/python/test_rticonnextdds_connector.py
@@ -6,6 +6,7 @@
 # This code contains trade secrets of Real-Time Innovations, Inc.             #
 ###############################################################################
 
+from platform import version
 import sys
 import os
 import re
@@ -106,102 +107,22 @@ class TestConnector:
                 url=xml_path) as connector:
             assert connector is not None
 
-    def test_native_library_version_getter(self):
-        """
-        native_library_version is a static method that can be can be called
-        either before or after the creation of a Connector instance. It
-        returns a structure containing the release of the native libraries.
-        """
-        # Ensure that we can call native_library_version before creating an
-        # instance of Connector
-        native_library_version = rti.Connector.native_library_version()
-        assert native_library_version is not None
-        assert isinstance(native_library_version, rti.ConnectorVersion)
-
-        # The returned version should contain a major, minor, release and revision
-        # field
-        assert isinstance(native_library_version.major, int)
-        assert isinstance(native_library_version.minor, int)
-        assert isinstance(native_library_version.release, int)
-        assert isinstance(native_library_version.revision, int)
-
-        # Create an instance of Connector and call the method again
-        participant_profile = "MyParticipantLibrary::ConnectorWithParticipantQos"
-        xml_path = os.path.join(os.path.dirname(
-                os.path.realpath(__file__)),
-                "../xml/TestConnector.xml")
-        with rti.open_connector(
-                config_name=participant_profile,
-                url=xml_path) as connector:
-            assert connector is not None
-            native_library_version2 = connector.native_library_version()
-            assert native_library_version2 is not None
-            assert isinstance(native_library_version2, rti.ConnectorVersion)
-
-        # Check that the str() method converts the ConnectorVersion class
-        # into the correct format (e.g., 6.1.0.0)
-        version_str = str(native_library_version)
-        assert bool(re.match("[0-9]\\.[0-9]\\.[0-9]\\.[0-9]", version_str)) == True
-
     def test_version_getter(self):
         """
-        Connector.version is a static method that can be can be called
-        either before or after the creation of a Connector instance. It
-        returns a structure containing information about the release of Connector
-        in use.
+        version is a static method that can be can be called
+        either before or after the creation of a Connector instance. It returns
+        a string providing information about the versions of the  native libraries
+        in use, and the version of the API.
         """
-        # Ensure that we can call native_library_version before creating an
-        # instance of Connector
-        version = rti.Connector.version()
-        assert version is not None
-        assert isinstance(version, rti.ConnectorVersion)
-
-        # The returned version should contain a major, minor, release and revision
-        # field
-        assert isinstance(version.major, int)
-        assert isinstance(version.minor, int)
-        assert isinstance(version.release, int)
-        assert isinstance(version.revision, int)
-
-        # Create an instance of Connector and call the method again
-        participant_profile = "MyParticipantLibrary::ConnectorWithParticipantQos"
-        xml_path = os.path.join(os.path.dirname(
-                os.path.realpath(__file__)),
-                "../xml/TestConnector.xml")
-        with rti.open_connector(
-                config_name=participant_profile,
-                url=xml_path) as connector:
-            assert connector is not None
-            version2 = connector.version()
-            assert version2 is not None
-            assert isinstance(version2, rti.ConnectorVersion)
-
-        # Check that the str() method converts the ConnectorVersion class
-        # into the correct format (e.g., "1.1.0.0")
-        version_str = str(version)
-        assert bool(re.match("[0-9]\\.[0-9]\\.[0-9]\\.[0-9]", version_str)) == True
-
-    def test_build_string_getter(self):
-
-        """
-        Connector.native_build_string is a static method that can be can be called
-        either before or after the creation of a Connector instance. It
-        returns a string containing information about the release of native
-        libraries being used by Connector.
-        """
-        build_str = rti.Connector.native_library_build_string()
-        assert build_str is not None
-        assert isinstance(build_str, str)
-
-        # Create an instance of Connector and call the method again
-        participant_profile = "MyParticipantLibrary::ConnectorWithParticipantQos"
-        xml_path = os.path.join(os.path.dirname(
-                os.path.realpath(__file__)),
-                "../xml/TestConnector.xml")
-        with rti.open_connector(
-                config_name=participant_profile,
-                url=xml_path) as connector:
-            assert connector is not None
-            build_str2 = rti.Connector.native_library_build_string()
-            assert build_str2 is not None
-            assert isinstance(build_str2, str)
+        # Ensure that we can call version before creating a Connector instance
+        version_str = rti.Connector.version()
+        assert version_str is not None
+        # The returned version should contain 4 pieces of information:
+        # - the API version of Connector
+        # - the build ID of core.1.0
+        # - the build ID of dds_c.1.0
+        # - the build ID of lua_binding.1.0
+        assert bool(re.match("RTI Connector for Python, version ([0-9]\\.){2}[0-9]", version_str, re.DOTALL)) == True
+        assert bool(re.match(".*NDDSCORE_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_str, re.DOTALL)) == True
+        assert bool(re.match(".*NDDSC_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_str, re.DOTALL)) == True
+        assert bool(re.match(".*RTICONNECTOR_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_str, re.DOTALL)) == True

--- a/test/python/test_rticonnextdds_connector.py
+++ b/test/python/test_rticonnextdds_connector.py
@@ -107,22 +107,22 @@ class TestConnector:
                 url=xml_path) as connector:
             assert connector is not None
 
-    def test_version_getter(self):
+    def test_get_version(self):
         """
         version is a static method that can be can be called
         either before or after the creation of a Connector instance. It returns
-        a string providing information about the versions of the  native libraries
+        a string providing information about the versions of the native libraries
         in use, and the version of the API.
         """
         # Ensure that we can call version before creating a Connector instance
-        version_str = rti.Connector.version()
-        assert version_str is not None
+        version_string = rti.Connector.get_version()
+        assert version_string is not None
         # The returned version should contain 4 pieces of information:
         # - the API version of Connector
         # - the build ID of core.1.0
         # - the build ID of dds_c.1.0
         # - the build ID of lua_binding.1.0
-        assert bool(re.match("RTI Connector for Python, version ([0-9]\\.){2}[0-9]", version_str, re.DOTALL)) == True
-        assert bool(re.match(".*NDDSCORE_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_str, re.DOTALL)) == True
-        assert bool(re.match(".*NDDSC_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_str, re.DOTALL)) == True
-        assert bool(re.match(".*RTICONNECTOR_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_str, re.DOTALL)) == True
+        assert bool(re.match("RTI Connector for Python, version ([0-9]\\.){2}[0-9]", version_string, re.DOTALL)) == True
+        assert bool(re.match(".*NDDSCORE_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_string, re.DOTALL)) == True
+        assert bool(re.match(".*NDDSC_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_string, re.DOTALL)) == True
+        assert bool(re.match(".*RTICONNECTOR_BUILD_([0-9]\\.){2}[0-9]_[0-9]{8}T[0-9]{6}Z", version_string, re.DOTALL)) == True


### PR DESCRIPTION
3 static methods have been added to Connector
 - version
   - Provides the current version of Connector
 - native_library_version
   - Provides the current version of native libraries being used by Connector
 - native_library_build_string
   - Provides the build ID of the native libraries being used by Connector