### PR TITLE
Con-191, CON-190 merge to 1.1.1 branch

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -138,19 +138,6 @@ To set any numeric type, including enumerations:
     output.instance.set_number("my_double", 2.14)
     output.instance.set_number("my_enum", 2)
 
-.. warning::
-    The range of values for a numeric field is determined by the type
-    used to define that field in the configuration file. However, ``set_number`` and
-    ``get_number`` can't handle 64-bit integers (*int64* and *uint64*)
-    whose absolute values are larger than 2^53. This is a *Connector* limitation
-    due to the use of *double* as an intermediate representation.
-
-    When ``set_number`` or ``get_number`` detect this situation, they will raise
-    an :class:`Error`. ``get_dictionary`` and ``set_dictionary`` do not have this
-    limitation and can handle any 64-bit integer.
-    An ``Instance``'s ``__setitem__`` method doesn't have
-    this limitation either, but ``SampleIterator``'s ``__getitem__`` does.
-
 To set booleans:
 
 .. testcode::
@@ -208,6 +195,38 @@ with numeric fields, returning the number as a string. For example:
     If a field ``my_string``, defined as a string in the configuration file,
     contains a value that can be interpreted as a number, ``sample["my_string"]``
     returns a number, not a string.
+
+Accessing 64-bit integers
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Internally, *Connector* relies on a framework that only contains a single number
+type, which is an IEEE-754 floating-point number. As a result, not all 64-bit integers
+can be represented with exact precision. If your type contains uint64 or int64 members,
+and you expect them to be larger than ``2^53`` (or smaller than ``-2^53``), then
+you must take the following into account.
+
+64-bit values with an absolute value greater or equal to 2^53 can be set via:
+ - The type-agnostic setter, ``__setitem__``. The values can be supplied as strings, or as numbers, e.g., ``the_output.instance["my_uint64"] = "18446744073709551615"``.
+ - The :meth:`Instance.set_string()` method, e.g., ``the_output.instance.set_string("my_uint64", "18446744073709551615")``
+ - The :meth:`Instance.set_dictionary()` method, e.g., ``the_output.instance.set_dictionary({"my_uint64": "18446744073709551615"})``
+
+64-bit values with an absolute value greater than 2^53 can be retrieved via:
+ - The type-agnostic getter, ``__getitem__``. The value will be an instance of ``int`` if larger than 2^53, otherwise a ``float``. e.g., ``sample["my_int64"] # 9223372036854775807``
+ - The :meth:`SampleIterator.get_string()`, method.
+   The value will be returned as a string, e.g., ``sample.get_string("my_int64") # "9223372036854775807"``
+ - The :meth:`SampleIterator.get_dictionary()` method, e.g., ``sample.get_dictionary()["my_int64"] # "9223372036854775807"``
+
+.. warning::
+
+  If :meth:`SampleIterator.get_number()` is used to retrieve a value > 2^53, an ``Error`` will be raised.
+
+.. warning::
+
+  If :meth:`Instance.set_number()` is used to set a value >= 2^53, an ``Error`` will be raised.
+
+.. note::
+
+  The :meth:`Instance.set_number()` operation can handle ``abs(value) < 2^53``,
+  whereas :meth:`SampleIterator.get_number()` can handle ``abs(value) <= 2^53``.
 
 Accessing structs
 ^^^^^^^^^^^^^^^^^

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -718,6 +718,9 @@ class SampleIterator:
     def get_number(self, field_name):
         """Gets the value of a numeric field in this sample
 
+        Note that this operation should not be used to retrieve values larger than
+        ``2^53``. See :ref:`Accessing 64-bit integers` for more information.
+
         :param str field_name: The name of the field. See :ref:`Accessing the data`.
         :return: The numeric value for the field ``field_name``.
         """
@@ -932,7 +935,9 @@ class Instance:
             raise AttributeError("field_name cannot be None")
 
         if isinstance(value, Number):
-            if value < connector_binding.max_integer_as_double:
+            # If |value| >= max_integer_as_double set via dictionary, working round
+            # the int-to-double conversion present in set_number
+            if value < connector_binding.max_integer_as_double and value > -connector_binding.max_integer_as_double:
                 self.set_number(field_name, value)
             else:
                 # Work around set_number int-to-double conversion
@@ -950,6 +955,10 @@ class Instance:
 
     def set_number(self, field_name, value):
         """Sets a numeric field
+
+
+        Note that this operation should not be used to set values larger than
+        ``2^53 - 1``. See :ref:`Accessing 64-bit integers` for more information.
 
         :param str field_name: The name of the field. See :ref:`Accessing the data`.
         :param number value: A numeric value or ``None`` to unset an optional member

--- a/test/python/test_rticonnextdds_metadata.py
+++ b/test/python/test_rticonnextdds_metadata.py
@@ -91,7 +91,6 @@ class TestMetadata:
     assert sample.info["sample_identity"] == expected_id
 
   def test_bad_guid(self, one_use_output):
-
     not_an_array = {"writer_guid": 3, "sequence_number": 10}
     with pytest.raises(rti.Error, match=r".*error parsing GUID.*") as excinfo:
       one_use_output.write(identity=not_an_array)
@@ -127,7 +126,6 @@ class TestMetadata:
       one_use_output.write(action="bad")
 
   def test_request_reply(self, requester, replier):
-
     request_id = {"writer_guid": [3]*16, "sequence_number": 10}
     requester.writer.instance['x'] = 10
     requester.writer.instance['y'] = 20


### PR DESCRIPTION
* CON-191: Added tests for 64-bit int conversions

* CON-191: Added docs

* CON-191: writer's edits to doc changes (py)

* CON-191: Updated tests and docs to reflect new behaviour

I noticed in the native libraries that we weren't being consistent with
the limits. Sometimes we were not checking for v < -LUA_MAX_INT, and sometimes
we were not being consistent with the use of > vs >=.
I have rectified this, the supported behaviour is as follows:

When setting via set_number, we allow |v| < 2^53.
When getting via get_number, we allow |v| <= 2^53.

The reason for the discrepancy between the set and get, is that
when we have a value in set_number, it has already been cast to a double,
so although 2^53 is perfectly representable, we do not know if the original
value was larger (e.g., 2^53 + 1 would appear as 2^53).

Also extended tests to ensure that all of the various supported ways
of setting / getting 64-bit values work as expected:
- allow setting large values via __setitem__ (string or number),
  set_string, set_dictionary
- allow getting large values via __getitem__ (returned as float or int
  depending on size), get_string, get_dictionary

* CON-191: Completed tests + docs

Co-authored-by: Sam Raeburn <sam@rti.com>
Co-authored-by: rkorte <rkorte@rti.com>
(cherry picked from commit 62a573cf15ca3bf085a5d1a63520005938c6f510)