### PR TITLE
Feature/con 251 py

### DIFF
--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -9,7 +9,7 @@ Copyrights and License
 © 2021 Real-Time Innovations, Inc. |br|
 All rights reserved.  |br|
 Printed in U.S.A. First printing.  |br|
-April 2021. |br|
+December 2021. |br|
 
 
 .. rubric:: License

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -226,12 +226,6 @@ you must take the following into account.
 
   If :meth:`Instance.set_number()` is used to set a value >= 2^53, an ``Error`` will be raised.
 
-.. warning::
-
-  On Windows systems, the string representations of Not a Number and infinity (e.g.,
-  ``'NaN'``, ``'Infinity'``) are not valid values for a Number. They are valid
-  inputs on other systems.
-
 .. note::
 
   The :meth:`Instance.set_number()` operation can handle ``abs(value) < 2^53``,

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -196,6 +196,9 @@ with numeric fields, returning the number as a string. For example:
     contains a value that can be interpreted as a number, ``sample["my_string"]``
     returns a number, not a string.
 
+
+.. _section-access-64-bit-integers:
+
 Accessing 64-bit integers
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 Internally, *Connector* relies on a framework that only contains a single number

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -51,8 +51,8 @@ New API makes it easier to query what version of Connector is being used
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. CON-92 
 
-A new API has been added that provides the caller with the version of *Connector*
-and the version of the native libraries being used.
+A new API, :meth:`rticonnextdds_connector.Connector.get_version`, has been added that provides the caller
+with the version of *Connector* and the version of the native libraries being used.
 
 
 What's Fixed in 1.2.0
@@ -70,6 +70,10 @@ Support added for handling large 64-bit integers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Support has been improved for both getting and setting large (greater than 2^53)
 64-bit values. See :ref:`section-access-64-bit-integers` for more information.
+
+Note that on Windows systems, the string representations of Not a Number and infinity
+(e.g., ``'NaN'``, ``'Infinity'``) are not valid values for a Number. They are valid
+inputs on other systems.
 
 [RTI Issue ID CON-190]
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
 =============
 
 Supported Platforms
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 *RTI Connector* works with Python® 2.x and 3.x. It uses a native C library that
 runs on most Windows®, Linux® and macOS® platforms.
@@ -37,25 +37,64 @@ repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
 
 What's New in 1.2.0
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
-*RTI Connector* 1.2.0 is built on `RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__.
+*Connector* 1.2.0 is built on `RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__.
 
 New Platforms
 ^^^^^^^^^^^^^
 
 RTI has validated that *Connector* can be used on macOS 11 (Big Sur) systems.
 
+
+New API makes it easier to query what version of Connector is being used
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. CON-92 
+
+A new API has been added that provides the caller with the version of *Connector*
+and the version of the native libraries being used.
+
+
+What's Fixed in 1.2.0
+---------------------
+
+Deleting same Connector object twice may have resulted in segmentation fault
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+A segmentation fault may have occurred when the same *Connector* object was
+deleted twice. This issue has been resolved.
+
+[RTI Issue ID CON-209]
+
+
+Support added for handling large 64-bit integers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Support has been improved for both getting and setting large (greater than 2^53)
+64-bit values. See :ref:`section-access-64-bit-integers` for more information.
+
+[RTI Issue ID CON-190]
+
+
 Previous Releases
-~~~~~~~~~~~~~~~~~
+-----------------
+
+Version 1.1.1
+^^^^^^^^^^^^^
+*Connector* 1.1.1 is built on *RTI Connext DDS* 6.1.0.3, which fixes several
+bugs in the Core Libraries. If you want more details on the bugs fixed in 6.1.0.3,
+contact support@rti.com. These bugs are also fixed in
+`RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__,
+upon which *RTI Connector* 1.2.0 is built.
+
+Version 1.1.0
+^^^^^^^^^^^^^
 
 What's New in 1.1.0
-^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""
 
-*RTI Connector* 1.1.0 is built on `RTI Connext DDS 6.1.0 <https://community.rti.com/documentation/rti-connext-dds-610>`__.
+*Connector* 1.1.0 is built on `RTI Connext DDS 6.1.0 <https://community.rti.com/documentation/rti-connext-dds-610>`__.
 
 Support added for ARMv8 architectures
-"""""""""""""""""""""""""""""""""""""
++++++++++++++++++++++++++++++++++++++
 .. CON-174 
 
 Connector for Python now runs on ARMv8 architectures. Native libraries
@@ -63,7 +102,7 @@ built for ARMv8 Ubuntu 16.04 are now shipped alongside Connector. These librarie
 have been tested on ARMv8 Ubuntu 16.04 and ARMv8 Ubuntu 18.04.
 
 Sample state, instance state, and view state can now be obtained in Connector
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. CON-177
 
 The SampleInfo class in *Connector* has been extended to provide access to the
@@ -73,7 +112,7 @@ the keys to the dictionary, in *Connector* for JavaScript they are the keys to t
 JSON Object).
 
 Support for accessing the key values of disposed instances
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. CON-188
 
@@ -87,7 +126,7 @@ sample as an object). When the instance state is NOT_ALIVE_DISPOSED, only the
 key values in the sample should be accessed.
 
 Support for Security, Monitoring and other Connext DDS add-on libraries
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. CON-221
 
@@ -96,10 +135,10 @@ that Connext DDS features such as Monitoring and Security Plugins are now suppor
 Refer to :ref:`Loading Connext DDS Add-On Libraries` for more information.
 
 What's Fixed in 1.1.0
-^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""
 
 Support for loading multiple configuration files
-""""""""""""""""""""""""""""""""""""""""""""""""
+++++++++++++++++++++++++++++++++++++++++++++++++
 
 A *Connector* object now supports loading multiple files. This allows separating
 the definition of types, QoS profiles, and *DomainParticipants* into different
@@ -112,7 +151,7 @@ files:
 [RTI Issue ID CON-209]
 
 Some larger integer values may have been corrupted by Connector's internal JSON parser
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 The internal JSON parser used in *Connector* failed to identify integer numbers
 from double-precision floating-point numbers for certain values.
@@ -123,7 +162,7 @@ become corrupted. This problem has been resolved.
 [RTI Issue ID CON-170]
 
 Creating two instances of Connector resulted in a license error
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Under some circumstances, it was not possible to create two *Connector* objects.
 The creation of the second *Connector* object failed due to a license error.
@@ -133,7 +172,7 @@ This issue has been fixed.
 [RTI Issue ID CON-163]
 
 Creating a Connector instance with a participant_qos tag in the XML may have resulted in a license error
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 In some cases, if the XML configuration file of *Connector* contained a
 `<participant_qos>` tag within the definition of the *DomainParticipant*,
@@ -143,7 +182,7 @@ This problem has been resolved.
 [RTI Issue ID CON-214]
 
 Version 1.0.0
-~~~~~~~~~~~~~
+^^^^^^^^^^^^^
 
 1.0.0 is the first official release of *RTI Connector for Python* as well as
 `RTI Connector for JavaScript <https://community.rti.com/static/documentation/connector/1.0.0/api/javascript/index.html>`__.


### PR DESCRIPTION
Make sure I put the new features/fixes in the right product (e.g., CON-209 is python only)

Will do these in separate PRs coming up:
- CON-234 (fix broken link)
- CON-252 (links to core docs should use release number, not 'current')
- Should we send copyright_license.rst page to Legal for review? Or do you know for a fact that hasn't changed?
