### PR TITLE
CORE-11993: canonical url added for python connector

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ def setup(app):
 #
 html_theme_options = {
     "collapse_navigation" : False
+    "canonical_url" : "https://community.rti.com/static/documentation/connector/current/api/python/"
 }
 
 # The name of an image file (relative to this directory) to place at the top


### PR DESCRIPTION
I see here that we added the canonical url to develop for js: https://github.com/rticommunity/rticonnextdds-connector-js/pull/66/files
And cherry-picked it to the 1.1.1 release branch for js: https://github.com/rticommunity/rticonnextdds-connector-js/pull/68/files

And I confirmed that I see the canonical url in develop and release/connector/1.2.0 for js. But I do not see it in develop or release/connector/1.2.0 for py. So I am adding it here.