### PR TITLE
CORE-11993: canonical url added for python connector

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ def setup(app):
 #
 html_theme_options = {
     "collapse_navigation" : False
+    "canonical_url" : "https://community.rti.com/static/documentation/connector/current/api/python/"
 }
 
 # The name of an image file (relative to this directory) to place at the top


### PR DESCRIPTION
@samuelraeburn, here is a cherry-pick of the canonical url for py connector, merged to develop here: https://github.com/rticommunity/rticonnextdds-connector-py/pull/106.