### PR TITLE
CON-234: fixing link to Python API reference

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -11,7 +11,7 @@ leading ultra-high performance, distributed networking databus.
 
 *RTI Connector* is a family of simplified APIs for publishing and subscribing
 to the *Connext DDS* Databus in programming languages such as Python and JavaScript. 
-(RTI also offers a more comprehensive `Python API <https://community.rti.com/static/documentation/connext-dds/current/doc/api/connext_dds/api_python/intro.html>`__, 
+(RTI also offers a more comprehensive `Python API <https://github.com/rticommunity/connextdds-py>`__, 
 which is experimental.)
 
 .. note::

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -11,7 +11,7 @@ leading ultra-high performance, distributed networking databus.
 
 *RTI Connector* is a family of simplified APIs for publishing and subscribing
 to the *Connext DDS* Databus in programming languages such as Python and JavaScript. 
-(RTI also offers a more comprehensive `Python API <https://community.rti.com/static/documentation/connext-dds/current/api/connext_dds/api_python/intro.html>`__, 
+(RTI also offers a more comprehensive `Python API <https://community.rti.com/static/documentation/connext-dds/current/doc/api/connext_dds/api_python/intro.html>`__, 
 which is experimental.)
 
 .. note::


### PR DESCRIPTION
According to Alex in HMAINT-276, I can count on the Python API URL being like the other API URLs. So although this link to the Python API reference doesn't work yet, it will:
https://community.rti.com/static/documentation/connext-dds/current/doc/api/connext_dds/api_python/intro.html