### PR TITLE
CON-251: added missing release note and fixed canonical formatting error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ def setup(app):
 # documentation.
 #
 html_theme_options = {
-    "collapse_navigation" : False
+    "collapse_navigation" : False,
     "canonical_url" : "https://community.rti.com/static/documentation/connector/current/api/python/"
 }
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -58,6 +58,21 @@ with the version of *Connector* and the version of the native libraries being us
 What's Fixed in 1.2.0
 ---------------------
 
+Error logged when accessing string longer than 128 bytes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Previously, on an input, when accessing a string longer than 128 bytes, the
+following error was printed:
+
+.. code-block::
+
+    Output buffer too small for member (name = "frame", id = 1). Provided size (128), requires size (x).
+
+This error message was innocuous; there was actually no issue with retrieving
+the string. The message is no longer printed.
+
+[RTI Issue ID CON-157]
+
+
 Deleting same Connector object twice may have resulted in segmentation fault
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 A segmentation fault may have occurred when the same *Connector* object was


### PR DESCRIPTION
@samuelraeburn, we forgot a release note: CON-157. Also, while building these docs, I got an error: I forgot to put a comma after "False" in conf.py when I added the canonical_url.