### PR TITLE
#fix HMAINT-202 -- new connector libraries for python, base on DDS 6.1.1 (20211203)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0',
+    version='1.2.0-rc3',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
Update reference to rticonnector libraries at 20211203.
Update setup.py to 1.2.0-rc3.
Note: docs/conf.py was *not* updated.

Pending:
Push to testpi.py for install testing
Update just setup.py back to 1.2.0 and push results to production once install testing has completed.