### PR TITLE
#fix HMAINT-202 -- corrected library git references for py, base on DDS 6.1.1 (20211203)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0-rc3',
+    version='1.2.0-rc4',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
Corrected references in rticonnextdds-connector to also point to 1.2.0