### PR TITLE
CON-257: adding Lua vulnerability assessment to Connector 1.2.0 doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath('../rticonnextdds_connector'))
 # -- Project information -----------------------------------------------------
 
 project = 'RTI Connector for Python'
-copyright = '2021, Real-Time Innovations, Inc'
+copyright = '2022, Real-Time Innovations, Inc'
 author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -6,10 +6,10 @@
 Copyrights and License
 **********************
 
-© 2021 Real-Time Innovations, Inc. |br|
+© 2022 Real-Time Innovations, Inc. |br|
 All rights reserved.  |br|
 Printed in U.S.A. First printing.  |br|
-December 2021. |br|
+February 2022. |br|
 
 
 .. rubric:: License
@@ -56,13 +56,15 @@ Phone: (408) 990-7444 |br|
 Email: support@rti.com |br|
 Website: https://support.rti.com/ |br|
 
-© 2021 RTI
+© 2022 RTI
 
 .. rubric:: External Third-Party Software Used in Connector
 
 **Lua**
   * The source code of this software is used to build the native libraries
     provided by *RTI Connector*.
+
+  * Version 5.2.
 
   * License (https://www.lua.org/license.html):
     Copyright © 1994–2021 Lua.org, PUC-Rio.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -96,8 +96,8 @@ inputs on other systems.
 Vulnerability Assessments
 -------------------------
 Internally, *Connector* relies on Lua. RTI has assessed the current version of 
-Lua used by *Connector*, version 5.2, and found that it is not currently 
-affected by publicly disclosed vulnerabilities.
+Lua used by *Connector*, version 5.2, and found that *Connector* is not currently 
+affected by any of the publicly disclosed vulnerabilities in Lua 5.2.
 
 
 Previous Releases

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -93,10 +93,11 @@ inputs on other systems.
 [RTI Issue ID CON-190]
 
 
-Assessments related to vulnerabilities
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-RTI has assessed the current version of Lua used by *Connector*, version 5.2, 
-and found that it is not currently affected by publicly disclosed vulnerabilities.
+Vulnerability Assessments
+-------------------------
+Internally, *Connector* relies on Lua. RTI has assessed the current version of 
+Lua used by *Connector*, version 5.2, and found that it is not currently 
+affected by publicly disclosed vulnerabilities.
 
 
 Previous Releases

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -93,6 +93,12 @@ inputs on other systems.
 [RTI Issue ID CON-190]
 
 
+Assessments related to vulnerabilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+RTI has assessed the current version of Lua used by *Connector*, version 5.2, 
+and found that it is not currently affected by publicly disclosed vulnerabilities.
+
+
 Previous Releases
 -----------------
 


### PR DESCRIPTION
We need to cherry-pick this to release/1.2.0. But what about the other Connector versions?