### PR TITLE
#fix HMAINT-202 -- new connector libraries for python, base on DDS 6.1.1 (20220309, bkprt)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0-rc5',
+    version='1.2.0-rc6',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
Candidate release, rc6, for 1.2.0. Here are the _BUILD_ strings for the libraries:
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm/libnddsc.so
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm/libnddscore.so
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm/librtiddsconnector.so
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm64/libnddsc.so
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm64/libnddscore.so
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm64/librtiddsconnector.so
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-x64/libnddsc.so
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-x64/libnddscore.so
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-x64/librtiddsconnector.so
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in win-x64/nddsc.dll
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in win-x64/nddscore.dll
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in win-x64/rtiddsconnector.dll
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in osx-x64/libnddsc.dylib
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in osx-x64/libnddscore.dylib
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in osx-x64/librtiddsconnector.dylib