### PR TITLE
#fix HMAINT-202 -- final version string 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0-rc6',
+    version='1.2.0',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
Final version string change to 1.2.0.
Note! This version goes directly to production as there is already a 1.2.0 version on test.py!