### PR TITLE
PY-44: adding deprecation notice to Connector Python for 7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ distributed networking databus.
 publish and subscribe to the *RTI Connext DDS databus* in Python and other
 languages.
 
+.. note::
+
+    With the introduction of the RTI Connext Python API in *RTI Connext* 7.0.0,  
+    *Connector for Python* is deprecated and will be removed in a 
+    future release, once the Connext Python API is fully supported. You are 
+    encouraged to try the 
+    `Connext Python API <https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/api/connext_dds/api_python/index.html>`__ 
+    (experimental in 7.0.0).  
+
 ## Documentation
 
 To get started and learn more about *RTI Connector for Python* see the

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,15 @@ performance, distributed networking databus.
 publish and subscribe to the *RTI Connext DDS databus* in Python and
 other languages.
 
+.. note::
+
+    With the introduction of the RTI Connext Python API in *RTI Connext* 7.0.0,  
+    *Connector for Python* is deprecated and will be removed in a 
+    future release, once the Connext Python API is fully supported. You are 
+    encouraged to try the 
+    `Connext Python API <https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/api/connext_dds/api_python/index.html>`__ 
+    (experimental in 7.0.0).  
+
 Documentation
 -------------
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -38,6 +38,15 @@ repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 What's New in 1.2.0
 -------------------
 
+.. note::
+
+    With the introduction of the RTI Connext Python API in *RTI Connext* 7.0.0,  
+    *Connector for Python* is deprecated and will be removed in a 
+    future release, once the Connext Python API is fully supported. You are 
+    encouraged to try the 
+    `Connext Python API <https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/api/connext_dds/api_python/index.html>`__ 
+    (experimental in 7.0.0).    
+
 *Connector* 1.2.0 is built on `RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__.
 
 New Platforms


### PR DESCRIPTION
@samuelraeburn, I don't remember if I created this branch off of develop or release/connector/1.2.0, but I think it was develop.

Is that why the built output still says 1.1.0 in the upper-left corner?? (But why?) The release notes are for 1.2.0.