### PR TITLE
CON-276: Updated loading of redist + commit of submodule

### DIFF
--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -139,7 +139,7 @@ class _ConnectorBinding:
             directory = "win-x64"
             libname = "rtiddsconnector"
             post = "dll"
-            additional_lib = "msvcr120"
+            additional_lib = "vcruntime140.dll"
             is_windows = True
         else:
             raise RuntimeError("This platform ({0}) is not supported".format(osname))


### PR DESCRIPTION
Updated loading of windows redistributable.

Updated rticonnextdds-connector submodule to feature/CON-276 branch:

```
Took all builds from BUILD_6.1.2.0_20221014T000000Z_RTI_REL build. All builds are licensed other than armv6.

Architectures used are as follows:
linux-arm: armv6vfphLinux3.xgcc4.7.2
linux-arm64: armv8Linux4.4gcc5.4.0
linux-x64: x64Linux2.6gcc4.4.5
win-x64: x64Win64VS2015
osx-x64: x64Darwin17clang9.0

Other than win-x64, these are identical to the architectures used in 1.2.0. Windows has been updated from VS2013 to VS2015. This meant also updating the redistributable to vcruntime140.dll.
```
