### PR TITLE
rticonnextdds-connector library changes and version string changes for release 1.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0',
+    version='1.2.2',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
Changed references in rticonnextdds-connector to latest develop branch changes in rticonnextdds-connector repository.
Changed version string to 1.2.2