### PR TITLE
Feature/con 272 276 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ distributed networking databus.
 publish and subscribe to the *RTI Connext DDS databus* in Python and other
 languages.
 
+**Note**: With the introduction of the RTI Connext Python API in *RTI Connext* 
+7.0.0, *Connector for Python* is deprecated and will be removed in a 
+future release, once the Connext Python API is fully supported. You are 
+encouraged to try the 
+[Connext Python API](https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/api/connext_dds/api_python/index.html) (experimental in 7.0.0).  
+
 ## Documentation
 
 To get started and learn more about *RTI Connector for Python* see the

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,14 @@ performance, distributed networking databus.
 publish and subscribe to the *RTI Connext DDS databus* in Python and
 other languages.
 
+.. note::
+
+   With the introduction of the RTI Connext Python API in *RTI Connext* 
+   7.0.0, *Connector for Python* is deprecated and will be removed in a 
+   future release, once the Connext Python API is fully supported. You are 
+   encouraged to try the 
+   `Connext Python API <https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/api/connext_dds/api_python/index.html>`__ (experimental in 7.0.0).
+
 Documentation
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,15 @@ You can learn how to use *RTI Connector* by reading the following sections, whic
 include examples and detailed API reference. You can also find a specific type
 or function in the :ref:`genindex`.
 
+.. note::
+
+   With the introduction of the RTI Connext Python API in *RTI Connext* 
+   7.0.0, *Connector for Python* is deprecated and will be removed in a 
+   future release, once the Connext Python API is fully supported. You are 
+   encouraged to try the 
+   `Connext Python API <https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/api/connext_dds/api_python/index.html>`__ (experimental in 7.0.0).
+
+
 Table of Contents
 =================
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -10,9 +10,7 @@ data distribution efficient and robust. At its core is the world's
 leading ultra-high performance, distributed networking databus.
 
 *RTI Connector* is a family of simplified APIs for publishing and subscribing
-to the *Connext DDS* Databus in programming languages such as Python and JavaScript. 
-(RTI also offers a more comprehensive `Python API <https://github.com/rticommunity/connextdds-py>`__, 
-which is experimental.)
+to the *Connext DDS* Databus in programming languages such as Python and JavaScript.
 
 .. note::
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -33,8 +33,16 @@ runs on most Windows®, Linux® and macOS® platforms.
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
 
+Version 1.2.2
+-----------------
+
+What's New in 1.2.2
+^^^^^^^^^^^^^^^^^^^
+
+*Connector* 1.2.2 is built on `RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
+
 Native Windows libraries updated to Visual Studio 2015
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
 .. CON-276
 
 Previously, the native libraries shipped with Connector were built using Visual
@@ -43,20 +51,33 @@ libraries are now built using Visual Studio 2015. The redistributable that is
 shipped has been updated accordingly.
 
 
+Vulnerability Assessments
+-------------------------
+Internally, *Connector* relies on Lua. RTI has assessed the current version of 
+Lua used by *Connector*, version 5.2, and found that *Connector* is not currently 
+affected by any of the publicly disclosed vulnerabilities in Lua 5.2.
+
+
+Previous Releases
+-----------------
+
+Version 1.2.0
+^^^^^^^^^^^^^
+
 What's New in 1.2.0
--------------------
+"""""""""""""""""""
 
 *Connector* 1.2.0 is built on `RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__.
 
 New Platforms
-^^^^^^^^^^^^^
++++++++++++++
 
 *Connector* has been validated on macOS 11 (Big Sur) systems on x64 and Arm v8 
 CPUs (via x64 libraries).
 
 
 New API makes it easier to query what version of Connector is being used
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. CON-92 
 
 A new API, :meth:`rticonnextdds_connector.Connector.get_version`, has been added that provides the caller
@@ -64,10 +85,10 @@ with the version of *Connector* and the version of the native libraries being us
 
 
 What's Fixed in 1.2.0
----------------------
+"""""""""""""""""""""
 
 Error logged when accessing string longer than 128 bytes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Previously, on an input, when accessing a string longer than 128 bytes, the
 following error was printed:
 
@@ -82,7 +103,7 @@ the string. The message is no longer printed.
 
 
 Deleting same Connector object twice may have resulted in segmentation fault
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 A segmentation fault may have occurred when the same *Connector* object was
 deleted twice. This issue has been resolved.
 
@@ -90,7 +111,7 @@ deleted twice. This issue has been resolved.
 
 
 Support added for handling large 64-bit integers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++++++++++++++++++++++++++
 Support has been improved for both getting and setting large (greater than 2^53)
 64-bit values. See :ref:`section-access-64-bit-integers` for more information.
 
@@ -99,17 +120,6 @@ Note that on Windows systems, the string representations of Not a Number and inf
 inputs on other systems.
 
 [RTI Issue ID CON-190]
-
-
-Vulnerability Assessments
--------------------------
-Internally, *Connector* relies on Lua. RTI has assessed the current version of 
-Lua used by *Connector*, version 5.2, and found that *Connector* is not currently 
-affected by any of the publicly disclosed vulnerabilities in Lua 5.2.
-
-
-Previous Releases
------------------
 
 Version 1.1.1
 ^^^^^^^^^^^^^

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -18,21 +18,29 @@ runs on most Windows®, Linux® and macOS® platforms.
   * Red Hat® Enterprise Linux 7, 7.3, 7.5, 7.6, 8 (x64)
   * SUSE® Linux Enterprise Server 12 SP2 (x64)
   * Ubuntu® 18.04 (x64, Arm v7, Arm v8)
-  * Ubuntu 20.04 LTS (x64)
+  * Ubuntu 20.04, 22.04 LTS (x64)
 
 **macOS**
-  * macOS 10.13-10.15 (x64)
+  * macOS 10.13-10.15, 12 (x64)
   * macOS 11 (x64 and Arm v8 tested via x64 libraries)
 
 **Windows**
-  * Windows 10 (x64)
-  * Windows Server 2012 R2 (x64)
+  * Windows 10, 11 (x64)
   * Windows Server 2016 (x64)
-
 
 *Connector* is supported in other languages in addition to Python, see the 
 `main Connector
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
+
+
+Native Windows libraries updated to Visual Studio 2015
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. CON-276
+
+Previously, the native libraries shipped with Connector were built using Visual
+Studio 2013 (and accompanied by Microsoft's mscvr120 redistributable). These
+libraries are now built using Visual Studio 2015. The redistributable that is
+shipped has been updated accordingly.
 
 
 What's New in 1.2.0


### PR DESCRIPTION
This pull request contains
 * the changes being merged into develop in [this PR](https://github.com/rticommunity/rticonnextdds-connector-py/pull/149) that add a deprecation notice about the Python Connector
 * I also fixed the release notes to contain a 1.2.2 version