### PR TITLE
CON-278 -- rc2 with libraries from 20221028

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags
 version = '1.2.0'
-release = '1.2.0'
+release = '1.2.2'
 
 master_doc = 'index'
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.2-rc1',
+    version='1.2.2-rc2',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
Updated git library links to the latest build in the common library repository. Changed docs version to 1.2.2 and bump the rc version to rc2.