### PR TITLE
CON-278 -- final version string for 1.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.2-rc3',
+    version='1.2.2',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
Removing the -rcX from the version string. Double checked libraries and they are all pointing to build NDDSCORE_BUILD_6.1.2.0_20221111T000000Z_RTI_REL.