### PR TITLE
REL-1907 -- Version string changes for 1.2.3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,8 @@ copyright = '2022, Real-Time Innovations, Inc'
 author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags
-version = '1.2.3-rc1'
-release = '1.2.3-rc1'
+version = '1.2.3'
+release = '1.2.3'
 
 master_doc = 'index'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,8 @@ copyright = '2022, Real-Time Innovations, Inc'
 author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags
-version = '1.2.2'
-release = '1.2.2'
+version = '1.2.3-rc1'
+release = '1.2.3-rc1'
 
 master_doc = 'index'
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -32,7 +32,6 @@ runs on most Windows®, Linux® and macOS® platforms.
 `main Connector
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
-
 Version 1.2.3
 -----------------
 
@@ -40,6 +39,14 @@ What's New in 1.2.3
 ^^^^^^^^^^^^^^^^^^^
 
 *Connector* 1.2.3 is built on `RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
+
+Version 1.2.2
+-----------------
+
+What's New in 1.2.2
+^^^^^^^^^^^^^^^^^^^
+
+*Connector* 1.2.2 is built on `RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
 
 Native Windows libraries updated to Visual Studio 2015
 """"""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -38,7 +38,7 @@ Version 1.2.3
 What's New in 1.2.3
 ^^^^^^^^^^^^^^^^^^^
 
-*Connector* 1.2.3 is built on `RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
+*Connector* 1.2.3 is built on `RTI Connext DDS 6.1.2.17 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
 
 Version 1.2.2
 -----------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -33,13 +33,13 @@ runs on most Windows®, Linux® and macOS® platforms.
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
 
-Version 1.2.2
+Version 1.2.3
 -----------------
 
-What's New in 1.2.2
+What's New in 1.2.3
 ^^^^^^^^^^^^^^^^^^^
 
-*Connector* 1.2.2 is built on `RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
+*Connector* 1.2.3 is built on `RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
 
 Native Windows libraries updated to Visual Studio 2015
 """"""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.2',
+    version='1.2.3-rc1',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
Update release notes replacing the string 1.2.2 with 1.2.3. 
Update the conf.py and setup.py files replacing 1.2.2 with 1.2.3-rc1.