### PR TITLE
REL-1928 -- update version with first release candidate, 1.2.3-rc1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.3-rc.1',
+    version='1.2.3-rc1',
 
     description='RTI Connector for Python',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.2',
+    version='1.2.3-rc.1',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
This is a required change to begin build/test of connext-py for 1.2.3. Using semvar 1.2.3-rc1 as we've done for 1.2.2.

Left all changes of doc/ to documentation, including the version string.