### PR TITLE
REL-1995 Release Notes for Connector 1.2.3

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -32,12 +32,22 @@ runs on most Windows®, Linux® and macOS® platforms.
 `main Connector
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
+Version 1.2.3
+-------------
 
-Version 1.2.2
+What's New in 1.2.3
+^^^^^^^^^^^^^^^^^^^
+
+*Connector* 1.2.3 is built on *RTI Connext DDS* 6.1.2.17. 
+
+Previous Releases
 -----------------
 
+Version 1.2.2
+^^^^^^^^^^^^^
+
 What's New in 1.2.2
-^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""
 
 *Connector* 1.2.2 is built on `RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
 
@@ -50,16 +60,12 @@ Studio 2013 (and accompanied by Microsoft's mscvr120 redistributable). These
 libraries are now built using Visual Studio 2015. The redistributable that is
 shipped has been updated accordingly.
 
+Vulnerability Assessment
+""""""""""""""""""""""""
 
-Vulnerability Assessments
--------------------------
 Internally, *Connector* relies on Lua. RTI has assessed the current version of 
 Lua used by *Connector*, version 5.2, and found that *Connector* is not currently 
 affected by any of the publicly disclosed vulnerabilities in Lua 5.2.
-
-
-Previous Releases
------------------
 
 Version 1.2.0
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Updating the Release Notes for Connector 1.2.3 (based on Connext 6.1.2.17)