### PR TITLE
REL-2031 -- change setup.py version string to final 1.2.3 ...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.3-rc1',
+    version='1.2.3',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
This should not happen prior to MIT passing. This needs to be done prior to uploading the final package to testpy and then pip production.