### PR TITLE
CON-314: Allow returning outstanding loans of Inputs, return loan on calling wait

### DIFF
--- a/docs/input.rst
+++ b/docs/input.rst
@@ -141,7 +141,30 @@ still provide the following information:
   ``'NOT_ALIVE_DISPOSED'``), the sample data contains the value of the key that
   has been disposed. You can access the key fields only. See
   :ref:`Accessing key values of disposed samples`.
-  
+
+Returning data and meta-data samples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The methods :meth:`Input.take()` and :meth:`Input.read()` modify the internal state
+of the :class:`Input` object, changing the available samples in the :attr:`Input.samples`.
+
+This data is available until the next call to :meth:`Input.take()` or :meth:`Input.read()`,
+but it is also possible to return the samples of the :class:`Input` object with
+:meth:`Input.return_loan()`:
+
+.. testcode::
+
+   input.return_loan()
+
+This is useful when you need to explicitly release resources associated with the
+:class:`Input` object.
+
+Additionally, it is also possible to return the samples of a specific :class:`Input`
+when calling :meth:`Input.wait()` with the ``return_samples`` parameter set to ``True``:
+
+.. testcode::
+
+   input.wait(return_samples=True)
 
 Matching with a publication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -145,18 +145,18 @@ still provide the following information:
 Returning data and meta-data samples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The methods :meth:`Input.take()` and :meth:`Input.read()` makes data accesible
+The methods :meth:`Input.take()` and :meth:`Input.read()` make data accesible
 through the :meth:`Input.samples` collection. This data is available until the
 next call to :meth:`Input.take()` or :meth:`Input.read()`.
 
 In some situations, data may need to be returned sooner so that new data can be
-received. To do that, you can call explicitly call :meth:`Input.return_samples()`:
+received. To do that, you can explicitly call :meth:`Input.return_samples()`:
 
 .. testcode::
 
    input.return_samples()
 
-Additionally, it is also possible to return samples when calling
+It is also possible to return samples when calling
 :meth:`Input.wait()` with the ``return_samples`` parameter set to ``True``:
 
 .. testcode::

--- a/docs/input.rst
+++ b/docs/input.rst
@@ -145,22 +145,19 @@ still provide the following information:
 Returning data and meta-data samples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The methods :meth:`Input.take()` and :meth:`Input.read()` modify the internal state
-of the :class:`Input` object, changing the available samples in the :attr:`Input.samples`.
+The methods :meth:`Input.take()` and :meth:`Input.read()` makes data accesible
+through the :meth:`Input.samples` collection. This data is available until the
+next call to :meth:`Input.take()` or :meth:`Input.read()`.
 
-This data is available until the next call to :meth:`Input.take()` or :meth:`Input.read()`,
-but it is also possible to return the samples of the :class:`Input` object with
-:meth:`Input.return_loan()`:
+In some situations, data may need to be returned sooner so that new data can be
+received. To do that, you can call explicitly call :meth:`Input.return_samples()`:
 
 .. testcode::
 
-   input.return_loan()
+   input.return_samples()
 
-This is useful when you need to explicitly release resources associated with the
-:class:`Input` object.
-
-Additionally, it is also possible to return the samples of a specific :class:`Input`
-when calling :meth:`Input.wait()` with the ``return_samples`` parameter set to ``True``:
+Additionally, it is also possible to return samples when calling
+:meth:`Input.wait()` with the ``return_samples`` parameter set to ``True``:
 
 .. testcode::
 

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -221,9 +221,9 @@ class _ConnectorBinding:
         self.take.restype = ctypes.c_int
         self.take.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 
-        self.return_loan = self.library.RTI_Connector_return_loan
-        self.return_loan.restype = ctypes.c_int
-        self.return_loan.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        self.return_samples = self.library.RTI_Connector_return_loan
+        self.return_samples.restype = ctypes.c_int
+        self.return_samples.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 
         self.wait = self.library.RTI_Connector_wait_for_data
         self.wait.restype = ctypes.c_int
@@ -828,15 +828,15 @@ class Input:
 
         _check_retcode(connector_binding.take(self.connector.native, tocstring(self.name)))
 
-    def return_loan(self):
-        """Returns any outstanding loan of samples by this Input
+    def return_samples(self):
+        """Returns any samples held by this Input
 
         After calling this method, the samples are no longer accessible from :attr:`samples`
 
         """
 
         _check_retcode(
-            connector_binding.return_loan(self.connector.native, tocstring(self.name))
+            connector_binding.return_samples(self.connector.native, tocstring(self.name))
         )
 
     @property
@@ -851,7 +851,7 @@ class Input:
 
         return self._samples
 
-    def wait(self, timeout=None, return_loan=True):
+    def wait(self, timeout=None, return_samples=False):
         """Wait for this input to receive data.
 
         This method waits for the specified timeout for data to be received by
@@ -859,12 +859,12 @@ class Input:
         If the operation times out, it raises :class:`TimeoutError`.
 
         :param number timeout: The maximum time to wait in milliseconds. By default, infinite.
-        :param bool return_loan: Whether to return outstanding loans before waiting. By default, ``True``.
+        :param bool return_samples: Whether to return outstanding loans before waiting. By default, ``False``.
         """
         if timeout is None:
             timeout = -1
-        if return_loan:
-            self.return_loan()
+        if return_samples:
+            self.return_samples()
         retcode = connector_binding.wait_for_data(self.native, timeout)
         _check_retcode(retcode)
 

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -221,6 +221,10 @@ class _ConnectorBinding:
         self.take.restype = ctypes.c_int
         self.take.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 
+        self.return_loan = self.library.RTI_Connector_return_loan
+        self.return_loan.restype = ctypes.c_int
+        self.return_loan.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
         self.wait = self.library.RTI_Connector_wait_for_data
         self.wait.restype = ctypes.c_int
         self.wait.argtypes = [ctypes.c_void_p, ctypes.c_int]
@@ -824,6 +828,17 @@ class Input:
 
         _check_retcode(connector_binding.take(self.connector.native, tocstring(self.name)))
 
+    def return_loan(self):
+        """Returns any outstanding loan of samples by this Input
+
+        After calling this method, the samples are no longer accessible from :attr:`samples`
+
+        """
+
+        _check_retcode(
+            connector_binding.return_loan(self.connector.native, tocstring(self.name))
+        )
+
     @property
     def samples(self):
         """Allows iterating over the samples read by this input
@@ -836,7 +851,7 @@ class Input:
 
         return self._samples
 
-    def wait(self, timeout=None):
+    def wait(self, timeout=None, return_loan=True):
         """Wait for this input to receive data.
 
         This method waits for the specified timeout for data to be received by
@@ -844,9 +859,12 @@ class Input:
         If the operation times out, it raises :class:`TimeoutError`.
 
         :param number timeout: The maximum time to wait in milliseconds. By default, infinite.
+        :param bool return_loan: Whether to return outstanding loans before waiting. By default, ``True``.
         """
         if timeout is None:
             timeout = -1
+        if return_loan:
+            self.return_loan()
         retcode = connector_binding.wait_for_data(self.native, timeout)
         _check_retcode(retcode)
 

--- a/rticonnextdds_connector/rticonnextdds_connector.py
+++ b/rticonnextdds_connector/rticonnextdds_connector.py
@@ -859,7 +859,7 @@ class Input:
         If the operation times out, it raises :class:`TimeoutError`.
 
         :param number timeout: The maximum time to wait in milliseconds. By default, infinite.
-        :param bool return_samples: Whether to return outstanding loans before waiting. By default, ``False``.
+        :param bool return_samples: Whether to return samples before waiting. By default and for backwards compatibility, ``False``. It is recommended to set it to ``True`` for most scenarios.
         """
         if timeout is None:
             timeout = -1

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -254,11 +254,13 @@ class TestDataAccess:
 
     # Initial set-up
     test_output.write() # Write1
+    time.sleep(.5)
     test_input.take()
     assert test_input.samples.length == 1 # Write1
 
     # Wait without returning samples
     test_output.write() # Write2
+    time.sleep(.5)
     test_input.wait(5000, return_samples=False)
     assert test_input.samples.length == 1 # Write1 was not returned
     test_input.take()
@@ -266,6 +268,7 @@ class TestDataAccess:
 
     # Wait with returning samples
     test_output.write() # Write3
+    time.sleep(.5)
     test_input.wait(5000, return_samples=True)
     assert test_input.samples.length == 0 # Write2 was returned
     test_input.take()

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -240,6 +240,15 @@ class TestDataAccess:
     dictionary = sample.get_dictionary()
     assert not "my_optional_point" in dictionary
 
+  def test_return_samples(self, test_output, test_input):
+    test_output.instance.set_number("my_long", 33)
+    test_output.write()
+    wait_for_data(test_input)
+    assert test_input.samples.length == 1
+    assert test_input.samples[0].get_number("my_long") == 33
+    test_input.return_samples()
+    assert test_input.samples.length == 1
+
   def test_reset_optional_number(self, test_output, test_input):
     test_output.instance.set_number("my_optional_long", 33)
     test_output.instance.set_number("my_optional_long", None)

--- a/test/python/test_rticonnextdds_data_access.py
+++ b/test/python/test_rticonnextdds_data_access.py
@@ -249,6 +249,28 @@ class TestDataAccess:
     test_input.return_samples()
     assert test_input.samples.length == 1
 
+  def test_return_samples_in_wait(self, test_output, test_input):
+    test_output.instance.set_number("my_long", 33)
+
+    # Initial set-up
+    test_output.write() # Write1
+    test_input.take()
+    assert test_input.samples.length == 1 # Write1
+
+    # Wait without returning samples
+    test_output.write() # Write2
+    test_input.wait(5000, return_samples=False)
+    assert test_input.samples.length == 1 # Write1 was not returned
+    test_input.take()
+    assert test_input.samples.length == 1 # Write2
+
+    # Wait with returning samples
+    test_output.write() # Write3
+    test_input.wait(5000, return_samples=True)
+    assert test_input.samples.length == 0 # Write2 was returned
+    test_input.take()
+    assert test_input.samples.length == 1 # Write3
+
   def test_reset_optional_number(self, test_output, test_input):
     test_output.instance.set_number("my_optional_long", 33)
     test_output.instance.set_number("my_optional_long", None)


### PR DESCRIPTION
* Added new `return_samples` method to `Input` class.
* Modify `wait` method to, by default, return the samples.

This requires accessing a new native function, thus requires new native libraries.