### PR TITLE
JH-81 -- late merge of support/connector/1.2.0 back into release/connector/1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ distributed networking databus.
 publish and subscribe to the *RTI Connext DDS databus* in Python and other
 languages.
 
-**Note**: With the introduction of the RTI Connext Python API in *RTI Connext* 
-7.0.0, *Connector for Python* is deprecated and will be removed in a 
-future release, once the Connext Python API is fully supported. You are 
-encouraged to try the 
-[Connext Python API](https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/api/connext_dds/api_python/index.html) (experimental in 7.0.0).  
+**Note**: With the introduction of the RTI Connext Python API in Connext 7.3.0 LTS,
+*Connector for Python* is deprecated for Connext DDS 6.1.2 users,
+and removed in Connext 7.3.0. To learn more about the Connext Python API, see
+[this documentation](https://community.rti.com/static/documentation/connext-dds/current/doc/api/connext_dds/api_python/index.html).
 
 ## Documentation
 

--- a/README.rst
+++ b/README.rst
@@ -9,13 +9,11 @@ performance, distributed networking databus.
 publish and subscribe to the *RTI Connext DDS databus* in Python and
 other languages.
 
-.. note::
-
-   With the introduction of the RTI Connext Python API in *RTI Connext* 
-   7.0.0, *Connector for Python* is deprecated and will be removed in a 
-   future release, once the Connext Python API is fully supported. You are 
-   encouraged to try the 
-   `Connext Python API <https://community.rti.com/static/documentation/connext-dds/7.0.0/doc/api/connext_dds/api_python/index.html>`__ (experimental in 7.0.0).
+**Note:**
+With the introduction of the RTI Connext Python API in Connext 7.3.0 LTS, 
+*Connector for Python* is deprecated for Connext DDS 6.1.2 users, 
+and removed in Connext 7.3.0. To learn more about the Connext Python API, see
+`this documentation <https://community.rti.com/static/documentation/connext-dds/current/doc/api/connext_dds/api_python/index.html>`__.  
 
 Documentation
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,8 @@ copyright = '2022, Real-Time Innovations, Inc'
 author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags
-version = '1.2.2'
-release = '1.2.2'
+version = '1.2.3'
+release = '1.2.3'
 
 master_doc = 'index'
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -32,12 +32,21 @@ runs on most Windows®, Linux® and macOS® platforms.
 `main Connector
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
+Version 1.2.3
+-------------
 
-Version 1.2.2
+*Connector* 1.2.3 is built on *RTI Connext DDS* 6.1.2.17. 
+For details on what's new and fixed in 6.1.2.17, contact support@rti.com. 
+There are no changes to Connector itself. 
+
+Previous Releases
 -----------------
 
+Version 1.2.2
+^^^^^^^^^^^^^
+
 What's New in 1.2.2
-^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""
 
 *Connector* 1.2.2 is built on `RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
 
@@ -49,17 +58,6 @@ Previously, the native libraries shipped with Connector were built using Visual
 Studio 2013 (and accompanied by Microsoft's mscvr120 redistributable). These
 libraries are now built using Visual Studio 2015. The redistributable that is
 shipped has been updated accordingly.
-
-
-Vulnerability Assessments
--------------------------
-Internally, *Connector* relies on Lua. RTI has assessed the current version of 
-Lua used by *Connector*, version 5.2, and found that *Connector* is not currently 
-affected by any of the publicly disclosed vulnerabilities in Lua 5.2.
-
-
-Previous Releases
------------------
 
 Version 1.2.0
 ^^^^^^^^^^^^^
@@ -236,3 +234,10 @@ more robust, modifies most of APIs and adds new functionality. However the old
 APIs have been preserved for backward compatibility as much as possible.
 
 *RTI Connector* 1.0.0 is built on `RTI Connext DDS 6.0.1 <https://community.rti.com/documentation/rti-connext-dds-601>`__.
+
+Vulnerability Assessment
+------------------------
+
+Internally, *Connector* relies on Lua. RTI has assessed the current version of 
+Lua used by *Connector*, version 5.2, and found that *Connector* is not currently 
+affected by any of the publicly disclosed vulnerabilities in Lua 5.2.

--- a/resources/jenkins/build_and_test.groovy
+++ b/resources/jenkins/build_and_test.groovy
@@ -45,7 +45,7 @@ pipeline {
         stage('Download dependencies') {
             steps {
                 downloadAndExtract(
-                    installDirectory: "rticonnextdds-connector/",
+                    installDirectory: '.',
                     flavour: 'connectorlibs'
                 )
             }

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.2',
+    version='1.2.3',
 
     description='RTI Connector for Python',
     long_description=long_description,


### PR DESCRIPTION
I've created this PR to expose the possible missing progression of release/connector/1.2.4. Could you guys have a look at the diffs and see if they make sense?

Here's what I did ...

```
# rticonnextdds-connector-py support/1.2.0 -> release/connector/1.2.4
#
git checkout support/connector/1.2.0 && git pull
git checkout release/connector/1.2.4 && git pull
git checkout -b feature/JH-81-gen-1.2.4-sup-1.2.0
git merge support/connector/1.2.0
git push origin feature/JH-81-gen-1.2.4-sup-1.2.0
```