### PR TITLE
REL-2593: updating connector-py release notes for 6.1.2.21

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath('../rticonnextdds_connector'))
 # -- Project information -----------------------------------------------------
 
 project = 'RTI Connector for Python'
-copyright = '2022, Real-Time Innovations, Inc'
+copyright = '2024, Real-Time Innovations, Inc'
 author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -66,7 +66,7 @@ Website: https://support.rti.com/ |br|
   * Version 5.2.
 
   * License (https://www.lua.org/license.html):
-    Copyright © 1994–2021 Lua.org, PUC-Rio.
+    Copyright © 1994-2021 Lua.org, PUC-Rio.
 
     Permission is hereby granted, free of charge, to any person obtaining a 
     copy of this software and associated documentation files (the "Software"), 
@@ -87,12 +87,12 @@ Website: https://support.rti.com/ |br|
     THE SOFTWARE.
 
 **json-parser**
-  * The source code of this software (from https://github.com/udp/json-parser) 
+  * The source code of this software (from https://github.com/json-parser/json-parser) 
     is used to build the native libraries provided by *RTI Connector*.
 
   * License:
 
-    Copyright (C) 2012, 2013, 2014 James McLaughlin et al.  All rights reserved.
+    Copyright (C) 2012-2021 the json-parser authors.  All rights reserved.
     https://github.com/udp/json-parser
 
     Redistribution and use in source and binary forms, with or without

--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -6,10 +6,10 @@
 Copyrights and License
 **********************
 
-© 2022 Real-Time Innovations, Inc. |br|
+© 2024 Real-Time Innovations, Inc. |br|
 All rights reserved.  |br|
 Printed in U.S.A. First printing.  |br|
-February 2022. |br|
+October 2024. |br|
 
 
 .. rubric:: License
@@ -56,7 +56,6 @@ Phone: (408) 990-7444 |br|
 Email: support@rti.com |br|
 Website: https://support.rti.com/ |br|
 
-© 2022 RTI
 
 .. rubric:: External Third-Party Software Used in Connector
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -33,8 +33,8 @@ runs on most Windows®, Linux® and macOS® platforms.
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
 
-Verion 1.2.4
-------------
+Version 1.2.4
+-------------
 *Connector* 1.2.4 is built on *RTI Connext DDS* 6.1.2.21. 
 For details on what's new and fixed in 6.1.2.21, contact support@rti.com. 
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -32,15 +32,42 @@ runs on most Windows®, Linux® and macOS® platforms.
 `main Connector
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
-Version 1.2.3
--------------
 
+Verion 1.2.4
+------------
+*Connector* 1.2.4 is built on *RTI Connext DDS* 6.1.2.21. 
+For details on what's new and fixed in 6.1.2.21, contact support@rti.com. 
+
+What's Fixed in 1.2.4
+^^^^^^^^^^^^^^^^^^^^^
+
+Wait operation on Input may have led to deadlock
+""""""""""""""""""""""""""""""""""""""""""""""""
+Using the ``wait`` operation of an ``Input`` after doing ``read`` or ``take``
+could have led to a deadlock scenario. This only happened if ``read`` or
+``take`` returned the the maximum amount of samples that an ``Input`` can hold.
+
+To remedy this, a new ``return_samples`` operation has been added to Inputs.
+Additionally, the ``wait`` operation can take a ``return_samples=True`` keyword
+argument to trigger the functionality. This behavior is not enabled by default,
+to be backwards compatible.
+
+.. code:: python
+
+   my_input.wait(return_samples=True)
+
+[RTI Issue ID CON-314]
+
+
+Previous Releases
+-----------------
+
+Version 1.2.3
+^^^^^^^^^^^^^
 *Connector* 1.2.3 is built on *RTI Connext DDS* 6.1.2.17. 
 For details on what's new and fixed in 6.1.2.17, contact support@rti.com. 
 There are no changes to Connector itself. 
 
-Previous Releases
------------------
 
 Version 1.2.2
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Here is the documentation output associated with this PR: https://jenkins-community.rti.com/job/ci/job/Connector-PY/job/rticonnextdds-connector-py-doc/view/change-requests/job/PR-189/Connector_20Documentation/release_notes.html